### PR TITLE
Add simple auto play functionality

### DIFF
--- a/demo/content/misc.md
+++ b/demo/content/misc.md
@@ -67,3 +67,29 @@ title: 'Miscellaneous'
   </slide>
 </ssr-carousel>
 ```
+
+## Autoplay features
+
+<ssr-carousel
+  :slides-per-page='1'
+  :autoplay-delay='5'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+  <slide :index='6'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel
+  :slides-per-page='1'
+  :autoplay-delay='5'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+  <slide :index='6'></slide>
+</ssr-carousel>
+```

--- a/src/concerns/autoplay.coffee
+++ b/src/concerns/autoplay.coffee
@@ -8,10 +8,13 @@ export default
 			type: Number
 			default: 0
 
+		pauseOnFocus:
+			type: Boolean
+			default: true
+
 	computed:
 		# Stop animation if window is hidden or if carousel is focused
-		paused: -> @windowHidden or @isFocused
-
+		paused: -> (@windowHidden or @isFocused) if @pauseOnFocus
 
 	mounted: ->
 		if @autoplayDelay then @autoPlayInterval = setInterval (() =>

--- a/src/concerns/autoplay.coffee
+++ b/src/concerns/autoplay.coffee
@@ -14,11 +14,20 @@ export default
 
 	computed:
 		# Stop animation if window is hidden or if carousel is focused
-		paused: -> (@windowHidden or @isFocused) if @pauseOnFocus
+		autoplayPaused: -> (@windowHidden or @isFocused) if @pauseOnFocus
 
-	mounted: ->
-		if @autoplayDelay then @autoPlayInterval = setInterval (() =>
-			@next() if not @paused
-			), @autoplayDelay * 1000
+	watch:
+		autoplayPaused: (paused) ->
+			if paused then @autoplayStop() else @autoplayStart()
 
-	beforeUnmount: -> clearInterval @autoPlayInterval
+	mounted: -> @autoplayStart()
+
+	beforeDestroy: -> @autoplayStop()
+
+	methods:
+		autoplayStart: ->
+			if @autoplayDelay then @autoPlayInterval = setInterval (() =>
+				@next() if not @autoplayPaused
+				), @autoplayDelay * 1000
+
+		autoplayStop: -> clearInterval @autoPlayInterval

--- a/src/concerns/autoplay.coffee
+++ b/src/concerns/autoplay.coffee
@@ -1,0 +1,21 @@
+###
+Code related to auotplay features of the carousel
+###
+export default
+	props:
+		# A delay provided in seconds for the autoplay. 0 is disabled
+		autoplayDelay:
+			type: Number
+			default: 0
+
+	computed:
+		# Stop animation if window is hidden or if carousel is focused
+		paused: -> @windowHidden or @isFocused
+
+
+	mounted: ->
+		if @autoplayDelay then @autoPlayInterval = setInterval (() =>
+			@next() if not @paused
+			), @autoplayDelay * 1000
+
+	beforeUnmount: -> clearInterval @autoPlayInterval

--- a/src/concerns/focus.coffee
+++ b/src/concerns/focus.coffee
@@ -24,5 +24,5 @@ export default
 		return unless @watchesHover
 		document.addEventListener 'visibilitychange', @updateVisibility
 
-	beforeUnmount: ->
+	beforeDestroy: ->
 		document.removeEventListener 'visibilitychange', @updateVisibility

--- a/src/concerns/focus.coffee
+++ b/src/concerns/focus.coffee
@@ -6,7 +6,6 @@ export default
 	# Some simple data about our component and window its mounted on
 	data: ->
 		hovered: false
-		buttonFocused: false
 		windowVisible: true
 
 	computed:
@@ -22,6 +21,7 @@ export default
 
 	# Watch the visibility updates of our document
 	mounted: ->
+		return unless @watchesHover
 		document.addEventListener 'visibilitychange', @updateVisibility
 
 	beforeUnmount: ->

--- a/src/concerns/focus.coffee
+++ b/src/concerns/focus.coffee
@@ -1,0 +1,28 @@
+###
+Code related to focus and hover state
+###
+export default
+
+	# Some simple data about our component and window its mounted on
+	data: ->
+		hovered: false
+		buttonFocused: false
+		windowVisible: true
+
+	computed:
+		isFocused: -> @windowVisible and @hovered
+		windowHidden: -> !@windowVisible
+
+	methods:
+		onEnter: -> @hovered = true
+		onLeave: -> @hovered = false
+
+		# Updates @windowVisible based on our document
+		updateVisibility: -> @windowVisible = !document.hidden
+
+	# Watch the visibility updates of our document
+	mounted: ->
+		document.addEventListener 'visibilitychange', @updateVisibility
+
+	beforeUnmount: ->
+		document.removeEventListener 'visibilitychange', @updateVisibility

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -10,12 +10,7 @@
 	//- The overflow mask and drag target
 	.ssr-carousel-mask(
 		:class='{ pressing, disabled }'
-		v-on=`disabled ? {} : {
-			mousedown: onPointerDown,
-			touchstart: onPointerDown,
-			mouseenter: onEnter,
-			mouseleave: onLeave
-		}`)
+		v-on='maskListeners')
 
 		//- The container of the slides that animates
 		ssr-carousel-track(
@@ -85,6 +80,20 @@ export default
 		# UI enabling controls
 		showArrows: Boolean
 		showDots: Boolean
+
+	computed:
+		watchesHover: -> @autoplayDelay > 0
+
+		maskListeners: ->
+			return {} if @disabled
+			{
+				mousedown: @onPointerDown
+				touchstart: @onPointerDown
+				...(unless @watchesHover then {} else {
+					mouseenter: @onEnter
+					mouseleave: @onLeave
+				})
+			}
 
 </script>
 

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -13,6 +13,8 @@
 		v-on=`disabled ? {} : {
 			mousedown: onPointerDown,
 			touchstart: onPointerDown,
+			mouseenter: onEnter,
+			mouseleave: onLeave
 		}`)
 
 		//- The container of the slides that animates
@@ -51,7 +53,9 @@ import SsrCarouselDots from './ssr-carousel-dots'
 import SsrCarouselTrack from './ssr-carousel-track'
 
 # Concerns
+import autoplay from './concerns/autoplay'
 import dragging from './concerns/dragging'
+import focus from './concerns/focus'
 import pagination from './concerns/pagination'
 import responsive from './concerns/responsive'
 import tweening from './concerns/tweening'
@@ -62,7 +66,9 @@ export default
 
 	# Load concerns
 	mixins: [
+		autoplay
 		dragging
+		focus
 		pagination
 		responsive
 		tweening


### PR DESCRIPTION
Adds simple auto play functionality with `autoplayDelay` prop. Defaults to `0` for disabled and takes seconds for delay in seconds (can swap this back to ms if we want, but I think most delays on other carousels were done in seconds)

Also adds a `pauseOnFocus` prop that defaults to true. Setting to false allows the user to continue the autoScroll when the element is hovered.

