### PR TITLE
Add looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 - `slides-per-page` (`1`) - How many slides are shown per page.
 - `gutter` (`20`) - The size of the space between slides.  This can a number or any CSS resolvable string. See https://vue-ssr-carousel.netlify.app/gutters.
 - `responsive` (`[]`) - Adjust settings at breakpoints. See https://vue-ssr-carousel.netlify.app/responsive.
-- `looping` (`false`) - Boolean to enable looping / infinite scroll.
+- `loop` (`false`) - Boolean to enable looping / infinite scroll.
 - `paginate-by-slide` (`false`) - When `false`, dragging the carousel or interacting with the arrows will advance a full page of slides at a time.  When `true`, the carousel will come to a rest at each slide.
 - `show-arrows` (`false`) - Whether to show back/forward arrows. See https://vue-ssr-carousel.netlify.app/ui.
 - `show-dots` (`false`) - Whether to show dot style pagination dots. See https://vue-ssr-carousel.netlify.app/ui.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 - `slides-per-page` (`1`) - How many slides are shown per page.
 - `gutter` (`20`) - The size of the space between slides.  This can a number or any CSS resolvable string. See https://vue-ssr-carousel.netlify.app/gutters.
 - `responsive` (`[]`) - Adjust settings at breakpoints. See https://vue-ssr-carousel.netlify.app/responsive.
+- `looping` (`false`) - Boolean to enable looping / infinite scroll.
 - `paginate-by-slide` (`false`) - When `false`, dragging the carousel or interacting with the arrows will advance a full page of slides at a time.  When `true`, the carousel will come to a rest at each slide.
 - `show-arrows` (`false`) - Whether to show back/forward arrows. See https://vue-ssr-carousel.netlify.app/ui.
 - `show-dots` (`false`) - Whether to show dot style pagination dots. See https://vue-ssr-carousel.netlify.app/ui.

--- a/demo/components/layout/nav.vue
+++ b/demo/components/layout/nav.vue
@@ -19,6 +19,7 @@ export default
 		{ title: 'Responsive', path: '/responsive' }
 		{ title: 'Gutters', path: '/gutters' }
 		{ title: 'UI', path: '/ui' }
+		{ title: 'Looping', path: '/looping' }
 		{ title: 'Miscellaneous', path: '/misc' }
 	]
 

--- a/demo/components/slide.vue
+++ b/demo/components/slide.vue
@@ -36,6 +36,8 @@ export default
 	flex-center()
 	text-align center
 	fluid-space padding 's'
+	> div
+		width 100%
 
 // Increase slide text size
 .title

--- a/demo/components/slide.vue
+++ b/demo/components/slide.vue
@@ -3,7 +3,7 @@
 <template lang='pug'>
 
 .slide: div
-	.title Slide {{ index }}
+	.title(v-if='index') Slide {{ index }}
 	slot
 
 </template>

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -4,14 +4,14 @@ title: 'Looping / Inifinte Scroll'
 
 ## Basic looping
 
-<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -20,7 +20,7 @@ title: 'Looping / Inifinte Scroll'
 
 ## Cloned slides can contain components
 
-<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'
@@ -42,7 +42,7 @@ title: 'Looping / Inifinte Scroll'
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -1,8 +1,10 @@
 ---
-title: 'Looping / Wrap-Around / Infinite Scroll'
+title: 'Looping'
 ---
 
 ## Basic looping
+
+Looping is also known as `wrapAround` or `infinite` in other carousels.
 
 <ssr-carousel :slides-per-page='1' loop show-dots show-arrows>
   <slide :index='1'></slide>

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -1,0 +1,18 @@
+---
+title: 'Looping / Inifinte Scroll'
+---
+
+## Basic looping
+
+<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -1,5 +1,5 @@
 ---
-title: 'Looping / Inifinte Scroll'
+title: 'Looping / Wrap-Around / Infinite Scroll'
 ---
 
 ## Basic looping

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -5,9 +5,15 @@ title: 'Looping / Inifinte Scroll'
 ## Basic looping
 
 <ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
-  <slide :index='1'></slide>
-  <slide :index='2'></slide>
-  <slide :index='3'></slide>
+  <slide :index='1'>
+    <visual image='https://via.placeholder.com/150' :aspect='16/9'></visual>
+  </slide>
+  <slide :index='2'>
+   <visual image=https://via.placeholder.com/300' :aspect='16/9'></visual>
+  </slide>
+  <slide :index='3'>
+    <visual image=https://via.placeholder.com/400' :aspect='16/9'></visual>
+  </slide>
 </ssr-carousel>
 
 ```vue
@@ -16,3 +22,4 @@ title: 'Looping / Inifinte Scroll'
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
+```

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -5,15 +5,9 @@ title: 'Looping / Inifinte Scroll'
 ## Basic looping
 
 <ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
-  <slide :index='1'>
-    <visual image='https://via.placeholder.com/150' :aspect='16/9'></visual>
-  </slide>
-  <slide :index='2'>
-   <visual image=https://via.placeholder.com/300' :aspect='16/9'></visual>
-  </slide>
-  <slide :index='3'>
-    <visual image=https://via.placeholder.com/400' :aspect='16/9'></visual>
-  </slide>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
@@ -21,5 +15,51 @@ title: 'Looping / Inifinte Scroll'
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
+</ssr-carousel>
+```
+
+## Cloned slides can contain components
+
+<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+1'
+      :aspect='16/9'>
+    </visual>
+  </slide>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+2'
+      :aspect='16/9'>
+    </visual>
+  </slide>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+3'
+      :aspect='16/9'>
+    </visual>
+  </slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel :slides-per-page='1' :gutter='40' looping show-dots>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+1'
+      :aspect='16/9'>
+    </visual>
+  </slide>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+2'
+      :aspect='16/9'>
+    </visual>
+  </slide>
+  <slide>
+    <visual
+      image='https://via.placeholder.com/1920x1080?text=Slide+3'
+      :aspect='16/9'>
+    </visual>
+  </slide>
 </ssr-carousel>
 ```

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -42,18 +42,14 @@ title: 'Looping / Inifinte Scroll'
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'
+      lazyload
       :aspect='16/9'>
     </visual>
   </slide>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+2'
-      :aspect='16/9'>
-    </visual>
-  </slide>
-  <slide>
-    <visual
-      image='https://via.placeholder.com/1920x1080?text=Slide+3'
+      lazyload
       :aspect='16/9'>
     </visual>
   </slide>
@@ -64,18 +60,14 @@ title: 'Looping / Inifinte Scroll'
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'
+      lazyload
       :aspect='16/9'>
     </visual>
   </slide>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+2'
-      :aspect='16/9'>
-    </visual>
-  </slide>
-  <slide>
-    <visual
-      image='https://via.placeholder.com/1920x1080?text=Slide+3'
+      lazyload
       :aspect='16/9'>
     </visual>
   </slide>

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -4,14 +4,14 @@ title: 'Looping / Inifinte Scroll'
 
 ## Basic looping
 
-<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
+<ssr-carousel :slides-per-page='1' loop show-dots show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
+<ssr-carousel :slides-per-page='1' loop show-dots show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -20,7 +20,7 @@ title: 'Looping / Inifinte Scroll'
 
 ## Cloned slides can contain components
 
-<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
+<ssr-carousel :slides-per-page='1' loop>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'
@@ -42,7 +42,7 @@ title: 'Looping / Inifinte Scroll'
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' :gutter='40' loop show-dots>
+<ssr-carousel :slides-per-page='1' loop>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -20,11 +20,12 @@ title: 'Looping / Inifinte Scroll'
 
 ## Looping with multiple slides per page
 
+Note how the incomplete 2nd page is handled.  The 3rd and 1st slide are shown simulataneously. On the next advance forward, the track advances a half width so that the *new* first page contains the 1st and 2nd slide.
+
 <ssr-carousel :slides-per-page='2' loop show-dots show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
-  <slide :index='4'></slide>
 </ssr-carousel>
 
 ```vue
@@ -32,11 +33,12 @@ title: 'Looping / Inifinte Scroll'
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
-  <slide :index='4'></slide>
 </ssr-carousel>
 ```
 
 ## Cloned slides can contain components
+
+In this case, we're using [vue-visual](https://github.com/BKWLD/vue-visual) components to render image assets.  Note how lazy loading prevents the loading of the second image until you advance forward.
 
 <ssr-carousel :slides-per-page='1' loop>
   <slide>

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -18,6 +18,24 @@ title: 'Looping / Inifinte Scroll'
 </ssr-carousel>
 ```
 
+## Looping with multiple slides per page
+
+<ssr-carousel :slides-per-page='2' loop show-dots show-arrows>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel :slides-per-page='2' loop show-dots show-arrows>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+</ssr-carousel>
+```
+
 ## Cloned slides can contain components
 
 <ssr-carousel :slides-per-page='1' loop>

--- a/demo/package.json
+++ b/demo/package.json
@@ -21,6 +21,7 @@
 		"prism-themes": "^1.9.0",
 		"vue-balance-text": "^1.2.3",
 		"vue-detachable-header": "^0.2.0",
-		"vue-unorphan": "^1.2.3"
+		"vue-unorphan": "^1.2.3",
+		"vue-visual": "^2.5.4"
 	}
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -22,6 +22,6 @@
 		"vue-balance-text": "^1.2.3",
 		"vue-detachable-header": "^0.2.0",
 		"vue-unorphan": "^1.2.3",
-		"vue-visual": "^2.5.4"
+		"vue-visual": "^2.6.0"
 	}
 }

--- a/demo/pages/_page.vue
+++ b/demo/pages/_page.vue
@@ -80,8 +80,7 @@ h1
 
 // Seperate regions on a page
 h2
-	fluid-space margin-top, 'm'
-	fluid-space margin-bottom, 's'
+	fluid-space margin-top, 'l'
 	style-h2()
 
 // Syntax highlighting
@@ -89,9 +88,22 @@ h2
 	background darken(primary-background, 15%)
 	border 1px solid darken(primary-background, 30%)
 	basic-border-radius()
-	fluid-space margin-v, 's'
+	fluid-space margin-bottom, 's'
 >>> code
 	font-size 14px
 	line-height 1.2
+
+// Style body text, like notes
+p
+	line-height 1.5
+	color lighten(primary-background, 50%)
+
+	// Underline links
+	a
+		text-decoration underline
+
+// Add constant margins around demos
+.ssr-carousel
+	fluid-space margin-v, 's'
 
 </style>

--- a/demo/pages/_page.vue
+++ b/demo/pages/_page.vue
@@ -21,12 +21,14 @@ article
 <script lang='coffee'>
 import pageMixin from '@bkwld/cloak/mixins/page'
 import SsrCarousel from '../../src/ssr-carousel'
+import Visual from 'vue-visual'
+import 'vue-visual/index.css'
 
 export default
 	name: 'Page'
 	mixins: [ pageMixin ]
 
-	components: { SsrCarousel }
+	components: { SsrCarousel, Visual }
 
 	# Get Tower data
 	asyncData: ({ app, params, $content }) ->

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -10574,7 +10574,7 @@ vue-unorphan@^1.2.3:
   dependencies:
     unorphan "^1.2.1"
 
-vue-visual@^2.0.0:
+vue-visual@^2.0.0, vue-visual@^2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/vue-visual/-/vue-visual-2.5.4.tgz#3675bdea3a748bfc56775d88cdeaf27bd0f5e1c2"
   integrity sha512-UUMxj0l9vPyR9W28y3g5eel4JsznuBgaqgEm8EhG/Vi2QVhhaDRsTUj0fkN++YcmwXt2iJcpewRDy6ITxQsHjQ==

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -10574,10 +10574,10 @@ vue-unorphan@^1.2.3:
   dependencies:
     unorphan "^1.2.1"
 
-vue-visual@^2.0.0, vue-visual@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/vue-visual/-/vue-visual-2.5.4.tgz#3675bdea3a748bfc56775d88cdeaf27bd0f5e1c2"
-  integrity sha512-UUMxj0l9vPyR9W28y3g5eel4JsznuBgaqgEm8EhG/Vi2QVhhaDRsTUj0fkN++YcmwXt2iJcpewRDy6ITxQsHjQ==
+vue-visual@^2.0.0, vue-visual@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/vue-visual/-/vue-visual-2.6.0.tgz#083c6f83d755d59819db63e10ad249deef4da358"
+  integrity sha512-clCxWyA8YwjFOUSR+9vXXUomBto4v/+PqP/0DXtsIvOAACnKyDXtKRvHZzTY0EOfNinWZ/7NzTZ0aXgeYhJpVg==
 
 vue@^2.6.12:
   version "2.6.14"

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -44,20 +44,25 @@ export default
 		# The current slide or page index. It rounds differently depending on the
 		# direction of the velocity.  So that it eases to a stop in the direction
 		# the user was dragging.
-		dragIndex: ->
-			fractionalIndex = if @paginateBySlide
-			then @currentX / @slideWidth * -1
-			else @currentX / @pageWidth * -1
-			switch
+		dragIndex: -> switch
 
-				# If there is very little velocity, go to the closet page
-				when Math.abs(@dragVelocity) <= 2 then Math.round fractionalIndex
+			# If there is very little velocity, go to the closet page
+			when Math.abs(@dragVelocity) <= 2 then Math.round @fractionalIndex
 
-				# User was moving forward
-				when @dragVelocity < 0 then Math.ceil fractionalIndex
+			# User was moving forward
+			when @dragVelocity < 0 then Math.ceil @fractionalIndex
 
-				# User was moving backward
-				else Math.floor fractionalIndex
+			# User was moving backward
+			else Math.floor @fractionalIndex
+
+		# Determine the current index given the currentX as a fraction. For
+		# instance, when dragging forward, it will be like 0.1 and when you've
+		# dragged almost a full page, forward it would be 0.9.
+		fractionalIndex: ->
+			x = @currentX - @currentIncompletePageOffset
+			if @paginateBySlide
+			then x / @slideWidth * -1
+			else x / @pageWidth * -1
 
 		# Calculate the width of a slide
 		slideWidth: -> @pageWidth / @currentSlidesPerPage

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -41,9 +41,9 @@ export default
 
 	computed:
 
-		# The current slide or page index. It rounds differently depedning on the
+		# The current slide or page index. It rounds differently depending on the
 		# direction of the velocity.  So that it eases to a stop in the direction
-		# the user was dragging
+		# the user was dragging.
 		dragIndex: ->
 			fractionalIndex = Math.abs if @paginateBySlide
 			then @currentX / @slideWidth

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -45,9 +45,9 @@ export default
 		# direction of the velocity.  So that it eases to a stop in the direction
 		# the user was dragging.
 		dragIndex: ->
-			fractionalIndex = Math.abs if @paginateBySlide
-			then @currentX / @slideWidth
-			else @currentX / @pageWidth
+			fractionalIndex = if @paginateBySlide
+			then @currentX / @slideWidth * -1
+			else @currentX / @pageWidth * -1
 			switch
 
 				# If there is very little velocity, go to the closet page

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -98,7 +98,7 @@ export default
 			else
 
 				# Tween so the track is in bounds if it was out
-				if @isOutOfBounds
+				if @isOutOfBounds and not @loop
 					@targetX = @applyXBoundaries @currentX
 					@startTweening()
 
@@ -171,12 +171,15 @@ export default
 
 		# Prevent dragging from exceeding the min/max edges
 		applyBoundaryDampening: (x) -> switch
+			when @loop then x # Don't apply dampening
 			when x > 0 then Math.pow x, @boundaryDampening
 			when x < @endX then @endX - Math.pow @endX - x, @boundaryDampening
 			else @applyXBoundaries x
 
 		# Constraint the x value to the min and max values
-		applyXBoundaries: (x) -> Math.max @endX, Math.min 0, x
+		applyXBoundaries: (x) ->
+			if @loop then x # Don't apply boundaries
+			else Math.max @endX, Math.min 0, x
 
 		# Prevent the anchors and images from being draggable (like via their
 		# ghost outlines). Using this approach because the draggable html attribute

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -1,0 +1,8 @@
+###
+Code related to looping / infinite scroll
+###
+export default
+
+	# Add prop to enable looping
+	props:
+		looping: Boolean

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -6,9 +6,6 @@ export default
 	# Add prop to enable looping
 	props: loop: Boolean
 
-	# Store cloned slides
-	data: -> clonedLastSlide: null
-
 	computed:
 
 		# Put slides in order, applying rules related to looping
@@ -34,29 +31,3 @@ export default
 		trackOffset: ->
 			unless @loop then 0
 			else @currentSlideIndex * @slideWidth
-
-	methods:
-
-		# Clone a vnode, based on
-		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89
-		cloneVnode: (vnode) ->
-			cloned = new vnode.constructor(
-				vnode.tag,
-				vnode.data,
-				vnode.children && vnode.children.slice(),
-				vnode.text,
-				vnode.elm,
-				vnode.context,
-				vnode.componentOptions,
-				vnode.asyncFactory
-			)
-			cloned.ns = vnode.ns
-			cloned.isStatic = vnode.isStatic
-			cloned.key = vnode.key
-			cloned.isComment = vnode.isComment
-			cloned.fnContext = vnode.fnContext
-			cloned.fnOptions = vnode.fnOptions
-			cloned.fnScopeId = vnode.fnScopeId
-			cloned.asyncMeta = vnode.asyncMeta
-			cloned.isCloned = true
-			return cloned

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -4,24 +4,36 @@ Code related to looping / infinite scroll
 export default
 
 	# Add prop to enable looping
-	props:
-		loop: Boolean
+	props: loop: Boolean
 
 	# Store cloned slides
-	data: ->
-		prependedSlides: []
-		appendedSlides: []
-
-	# Testing cloneVnode
-	# created: ->
-	# 	clone = @cloneVnode @$slots.default[1]
-	# 	@prependedSlides.push clone
+	data: -> clonedLastSlide: null
 
 	computed:
 
-		# Combine slotted slides and clones
-		slides: -> [...@prependedSlides, ...@slottedSlides, ...@appendedSlides]
+		# Put slides in order, applying rules related to looping
+		slides: ->
 
+			# If not looping, don't show other slides during boundary dampening
+			return @slottedSlides unless @loop
+
+			# Breakup the slides into arrays using the modulo of the current
+			# side index.  I came up with this by figuring out how the arrays should
+			# look and working back from there.
+			prepended = @slottedSlides.slice @currentSlideIndex % @slidesCount
+			remainder = @slottedSlides.slice 0, @slidesCount - prepended.length
+			return [ ...prepended, ...remainder ]
+
+		# This represents the current (as in while scrolling / animating) left most
+		# slide index. This is used in looping calculation so that the reordering
+		# of slides isn't affected by paginatePerSlide setting.
+		currentSlideIndex: -> Math.floor @currentX / @slideWidth * -1
+
+		# When looping, slides get re-ordered. This value is added to the
+		# track transform so that the slides don't feel like they were re-ordered.
+		trackOffset: ->
+			unless @loop then 0
+			else @currentSlideIndex * @slideWidth
 
 	methods:
 

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -20,7 +20,11 @@ export default
 	computed:
 
 		# Combine slotted slides and clones
-		slides: -> [...@prependedSlides, ...@$slots.default, ...@appendedSlides]
+		slides: -> [...@prependedSlides, ...@slottedSlides, ...@appendedSlides]
+
+		# Get just the slotted slides that are components, ignoring text nodes
+		# which may exist as a result of whitespace
+		slottedSlides: -> @$slots.default.filter (vnode) -> !!vnode.tag
 
 	methods:
 

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -13,9 +13,9 @@ export default
 		appendedSlides: []
 
 	# Testing cloneVnode
-	created: ->
-		clone = @cloneVnode @$slots.default[1]
-		@prependedSlides.push clone
+	# created: ->
+	# 	clone = @cloneVnode @$slots.default[1]
+	# 	@prependedSlides.push clone
 
 	computed:
 

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -6,3 +6,44 @@ export default
 	# Add prop to enable looping
 	props:
 		looping: Boolean
+
+	# Store cloned slides
+	data: ->
+		prependedSlides: []
+		appendedSlides: []
+
+	# Testing cloneVnode
+	created: ->
+		clone = @cloneVnode @$slots.default[1]
+		@prependedSlides.push clone
+
+	computed:
+
+		# Combine slotted slides and clones
+		slides: -> [...@prependedSlides, ...@$slots.default, ...@appendedSlides]
+
+	methods:
+
+		# Clone a vnode, based on
+		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89
+		cloneVnode: (vnode) ->
+			cloned = new vnode.constructor(
+				vnode.tag,
+				vnode.data,
+				vnode.children && vnode.children.slice(),
+				vnode.text,
+				vnode.elm,
+				vnode.context,
+				vnode.componentOptions,
+				vnode.asyncFactory
+			)
+			cloned.ns = vnode.ns
+			cloned.isStatic = vnode.isStatic
+			cloned.key = vnode.key
+			cloned.isComment = vnode.isComment
+			cloned.fnContext = vnode.fnContext
+			cloned.fnOptions = vnode.fnOptions
+			cloned.fnScopeId = vnode.fnScopeId
+			cloned.asyncMeta = vnode.asyncMeta
+			cloned.isCloned = true
+			return cloned

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -5,7 +5,7 @@ export default
 
 	# Add prop to enable looping
 	props:
-		looping: Boolean
+		loop: Boolean
 
 	# Store cloned slides
 	data: ->

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -22,9 +22,6 @@ export default
 		# Combine slotted slides and clones
 		slides: -> [...@prependedSlides, ...@slottedSlides, ...@appendedSlides]
 
-		# Get just the slotted slides that are components, ignoring text nodes
-		# which may exist as a result of whitespace
-		slottedSlides: -> @$slots.default.filter (vnode) -> !!vnode.tag
 
 	methods:
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -54,4 +54,9 @@ export default
 
 		# Apply boundaries to the index
 		applyIndexBoundaries: (index) ->
-			Math.max 0, Math.min @pages - 1, index
+			unless @loop
+			then Math.max 0, Math.min @pages - 1, index
+			else
+				if index < 0 then @pages + index
+				else if index >= @pages then index - @pages
+				else index

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -9,7 +9,7 @@ export default
 		paginateBySlide: Boolean
 
 	data: ->
-		index: 0 # The current page
+		index: 0 # The current page; when looping may exceed slideCount
 		currentX: 0 # The actual left offset of the slides container
 		targetX: 0 # Where we may be tweening the slide to
 
@@ -24,9 +24,8 @@ export default
 		# Disable carousel-ness when there aren't enough slides
 		disabled: -> @slidesCount <= @currentSlidesPerPage
 
-		# Filter out slides that have a "text" property, these aren't actual
-		# elements. They are whitespace, like newlines.
-		slidesCount: -> @slides.length
+		# Get the total number of slides
+		slidesCount: -> @slottedSlides.length
 
 	watch:
 
@@ -54,9 +53,5 @@ export default
 
 		# Apply boundaries to the index
 		applyIndexBoundaries: (index) ->
-			unless @loop
-			then Math.max 0, Math.min @pages - 1, index
-			else
-				if index < 0 then @pages + index
-				else if index >= @pages then index - @pages
-				else index
+			if @loop then index
+			else Math.max 0, Math.min @pages - 1, index

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -34,6 +34,9 @@ export default
 		# Apply boundaries to the index, which will exceed them when looping
 		boundedIndex: -> Math.abs(@index) % @pages
 
+		# The current incomplete page offset
+		currentIncompletePageOffset: -> @makeIncompletePageOffset @index
+
 	watch:
 
 		# Emit events on index change
@@ -57,11 +60,27 @@ export default
 
 		# Tween to a specific index
 		tweenToIndex: (index) ->
+
+			# Figure out the new x position
 			x = if @paginateBySlide
-			then index * @slideWidth
-			else index * @pageWidth
-			@targetX = @applyXBoundaries -1 * x
+			then index * @slideWidth * -1
+			else index * @pageWidth * -1
+
+			# Apply adjustments to x value and persist
+			x += @makeIncompletePageOffset index
+			@targetX = @applyXBoundaries x
+
+			# Start tweening
 			@startTweening()
+
+		# Creates a px value to represent adjustments that should be made to
+		# account for incommplete pages of slides when looping is enbaled. Like
+		# when there is 3 slotted slides and 2 slides per page.
+		makeIncompletePageOffset: (index) ->
+			return 0 unless @loop and not @paginateBySlide
+			Math.floor(index / @pages) *
+			(@slidesCount % @currentSlidesPerPage) *
+			@slideWidth
 
 		# Apply boundaries to the index
 		applyIndexBoundaries: (index) ->

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -27,16 +27,27 @@ export default
 		# Get the total number of slides
 		slidesCount: -> @slottedSlides.length
 
+		# Apply boundaries to the index, which will exceed them when looping
+		boundedIndex: ->
+			if @index < 0 then @pages + @index
+			else if @index >= @pages then @index - @pages
+			else @index
+
 	watch:
 
 		# Emit events on index change
-		index: -> @$emit 'change', { @index }
+		boundedIndex: -> @$emit 'change', { @boundedIndex }
 
 	methods:
 
 		# Advance methods
 		next: -> @goto @index + 1
 		back: -> @goto @index - 1
+
+		# The dots are ignorant of looping, so convert their bounded index to the
+		# true index so we don't animate through a ton of pages going to the
+		# clicked dot.
+		gotoDot: (dotIndex) -> @goto dotIndex - @boundedIndex + @index
 
 		# Go to a specific index
 		goto: (index) ->

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -32,10 +32,7 @@ export default
 		slidesCount: -> @slottedSlides.length
 
 		# Apply boundaries to the index, which will exceed them when looping
-		boundedIndex: ->
-			if @index < 0 then @pages + @index
-			else if @index >= @pages then @index - @pages
-			else @index
+		boundedIndex: -> Math.abs(@index) % @pages
 
 	watch:
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -24,6 +24,10 @@ export default
 		# Disable carousel-ness when there aren't enough slides
 		disabled: -> @slidesCount <= @currentSlidesPerPage
 
+		# Get just the slotted slides that are components, ignoring text nodes
+		# which may exist as a result of whitespace
+		slottedSlides: -> @$slots.default.filter (vnode) -> !!vnode.tag
+
 		# Get the total number of slides
 		slidesCount: -> @slottedSlides.length
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -27,7 +27,7 @@ export default
 		# Filter out slides that have a "text" property, these aren't actual
 		# elements. They are whitespace, like newlines.
 		slidesCount: ->
-			(@$slots.default || [])
+			@slides
 			.filter (vnode) -> !vnode?.text
 			.length
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -26,10 +26,7 @@ export default
 
 		# Filter out slides that have a "text" property, these aren't actual
 		# elements. They are whitespace, like newlines.
-		slidesCount: ->
-			@slides
-			.filter (vnode) -> !vnode?.text
-			.length
+		slidesCount: -> @slides.length
 
 	watch:
 

--- a/src/ssr-carousel-arrows.vue
+++ b/src/ssr-carousel-arrows.vue
@@ -30,12 +30,13 @@ export default
 	props:
 		index: Number
 		pages: Number
+		loop: Boolean
 
 	computed:
 
 		# Determine if button should be disabled because we're at the limits
-		backDisabled: -> @index == 0
-		nextDisabled: -> @index == @pages - 1
+		backDisabled: -> @index == 0 unless @loop
+		nextDisabled: -> @index == @pages - 1 unless @loop
 
 </script>
 

--- a/src/ssr-carousel-dots.vue
+++ b/src/ssr-carousel-dots.vue
@@ -6,7 +6,7 @@
 	button.ssr-carousel-dot-button(
 		v-for='i in pages' :key='i'
 		:aria-label='`Page ${i}`'
-		:disabled='index == i - 1'
+		:disabled='boundedIndex == i - 1'
 		@click='$emit("goto", i - 1)')
 			slot(v-if='$slots.dot' name='dot')
 			span.ssr-carousel-dot-icon(v-else)
@@ -19,7 +19,7 @@
 export default
 
 	props:
-		index: Number
+		boundedIndex: Number
 		pages: Number
 
 </script>

--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -9,6 +9,7 @@ export default
 	props:
 		dragging: Boolean
 		currentX: Number
+		slides: Array
 
 	computed:
 
@@ -19,8 +20,8 @@ export default
 	render: (create) ->
 
 		# Wrap the slides in ssr-carousel-slide functional components
-		children = @$slots.default.map (child) ->
-			if child.text then child # Text nodes like newlines
+		children = @slides.map (child) ->
+			unless child.tag then child # Text nodes like newlines
 			else create SsrCarouselSlide, { parent: this }, [ child ]
 
 		# Create the track div

--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -9,12 +9,13 @@ export default
 	props:
 		dragging: Boolean
 		currentX: Number
+		trackOffset: Number
 		slides: Array
 
 	computed:
 
 		# Styles that are used to position the track
-		styles: -> transform: "translateX(#{@currentX}px)"
+		styles: -> transform: "translateX(#{@currentX + @trackOffset}px)"
 
 	# Render the track and slotted slides
 	render: (create) ->

--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -21,8 +21,7 @@ export default
 
 		# Wrap the slides in ssr-carousel-slide functional components
 		children = @slides.map (child) ->
-			unless child.tag then child # Text nodes like newlines
-			else create SsrCarouselSlide, { parent: this }, [ child ]
+			create SsrCarouselSlide, { parent: this }, [ child ]
 
 		# Create the track div
 		create 'div',

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -82,8 +82,11 @@ export default
 		showDots: Boolean
 
 	computed:
+
+		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0
 
+		# Create event bindings
 		maskListeners: ->
 			return {} if @disabled
 			{

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -22,6 +22,7 @@
 		ssr-carousel-arrows(
 			v-if='showArrows'
 			v-bind='{ index, pages }'
+			:loop='loop'
 			@back='back'
 			@next='next')
 			template(#back): slot(name='back-arrow')

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -15,10 +15,8 @@
 		//- The container of the slides that animates
 		ssr-carousel-track(
 			ref='track'
+			:slides='slides'
 			v-bind='{ dragging, currentX }')
-
-			//- Slides are injected here
-			slot
 
 		//- Back / Next navigation
 		ssr-carousel-arrows(

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -51,6 +51,7 @@ import SsrCarouselTrack from './ssr-carousel-track'
 import autoplay from './concerns/autoplay'
 import dragging from './concerns/dragging'
 import focus from './concerns/focus'
+import looping from './concerns/looping'
 import pagination from './concerns/pagination'
 import responsive from './concerns/responsive'
 import tweening from './concerns/tweening'
@@ -64,6 +65,7 @@ export default
 		autoplay
 		dragging
 		focus
+		looping
 		pagination
 		responsive
 		tweening

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -21,7 +21,7 @@
 			ssr-carousel-track(
 				ref='track'
 				:slides='slides'
-				v-bind='{ dragging, currentX }')
+				v-bind='{ dragging, currentX, trackOffset }')
 
 		//- Back / Next navigation
 		ssr-carousel-arrows(

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -7,16 +7,21 @@
 	//- Render generated styles
 	component(is='style' v-html='instanceStyles')
 
-	//- The overflow mask and drag target
-	.ssr-carousel-mask(
-		:class='{ pressing, disabled }'
-		v-on='maskListeners')
+	//- Container so that arrows can be centered relative to slides but not be
+	//- within the mask's overflow:hidden (which prevents overriding styles from
+	//- positioning outside of carousel).
+	.ssr-carousel-slides
 
-		//- The container of the slides that animates
-		ssr-carousel-track(
-			ref='track'
-			:slides='slides'
-			v-bind='{ dragging, currentX }')
+		//- The overflow mask and drag target
+		.ssr-carousel-mask(
+			:class='{ pressing, disabled }'
+			v-on='maskListeners')
+
+			//- The container of the slides that animates
+			ssr-carousel-track(
+				ref='track'
+				:slides='slides'
+				v-bind='{ dragging, currentX }')
 
 		//- Back / Next navigation
 		ssr-carousel-arrows(
@@ -108,6 +113,10 @@ export default
 // Prevent webkit from doing elastic dragging horizontally on drag
 .ssr-carousel
 	touch-action pan-y
+
+// Posiition arrows relative to this
+.ssr-carousel-slides
+	position relative
 
 // Mask around slides
 .ssr-carousel-mask

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -36,8 +36,8 @@
 	//- Dots navigation
 	ssr-carousel-dots(
 		v-if='showDots'
-		v-bind='{ index, pages }'
-		@goto='goto')
+		v-bind='{ boundedIndex, pages }'
+		@goto='gotoDot')
 		template(#dot): slot(name='dot')
 
 </template>


### PR DESCRIPTION
- [x] POC cloning a slide
- [x] Test cloning a slide containing child components (like vue-visual)
  - ~I'm not sure if current approach needs to recursively clone children, some of the examples I found depended on that~ Seems to be fine w/o
  - [x] We'll need https://github.com/BKWLD/vue-visual/issues/61 to prevent flickering when switching slides (I'd rather not have to just always disable transitions because I like them for the initial load)
- [x] Implement looping pagination behavior
- [x] Disable bounding when loop is enabled
- [x] Support dragging to the left (currently always returns to index 0)
- [x] Make dots an emitted events return looped index values
- [x] Reorder slides and add offset when out of bounds
  - [x] Add support for multiple slides per page
  - [x] Fix whatever is up with pagination dots
- [x] When multiple slides per page and not enough to fill a page, fill with empty space so we don't run into issues with pagination.
  - For instance, with 5 slides and 2 per page, one 3rd page, if we don't make the rest of the slides empty, then `index` 4 would begin with slide 2 and everything gets more wonky from there.  
  - ~I think this is a better solution than, say, making page 3 a sort of half page ... that feels less loop-y to me.~
    - ~Could the `ssr-carousel-slide` add this ... like add `margin-right` equal to whatever is needed?  And only when `@loop`?~
    - I changed my mind, I think the code will be a lot cleaner if one move from last page to new first page, we just advance to the start of page 0.  I think UX is a wash, it has some pros and some cons but the simplicity of the code change wins out.  The gutter logic stays consistent this way and the carousel is always full looking.  
  - ~Update the docs to call out this behavior~

Closes #10, #29  