### PR TITLE
Add peeking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[README.md]
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 
 - `slides-per-page` (`1`) - How many slides are shown per page.
 - `gutter` (`20`) - The size of the space between slides.  This can a number or any CSS resolvable string. See https://vue-ssr-carousel.netlify.app/gutters.
-- `responsive` (`[]`) - Adjust settings at breakpoints. See https://vue-ssr-carousel.netlify.app/responsive.
-- `loop` (`false`) - Boolean to enable looping / infinite scroll.
+- `responsive` (`[]`) - Adjust settings at breakpoints. See https://vue-ssr-carousel.netlify.app/responsive.  The following properties can be set responsively: `slidesPerPage`, `gutter`, and any `peek` related property.
 - `paginate-by-slide` (`false`) - When `false`, dragging the carousel or interacting with the arrows will advance a full page of slides at a time.  When `true`, the carousel will come to a rest at each slide.
+- `loop` (`false`) - Boolean to enable looping / infinite scroll. See https://vue-ssr-carousel.netlify.app/looping.
+- `peek` (`0`) - A width value for how far adjacent cards should peek into the carousel canvas. This can a number or any CSS resolvable string. See https://vue-ssr-carousel.netlify.app/peeking.  There are couple related properties:
+  - `peek-left` - Set peek value on just the left edge.
+  - `peek-right` - Set peek value on just the right edge.
+  - `peek-gutter` - Set peek value on to the `gutter` value.
 - `show-arrows` (`false`) - Whether to show back/forward arrows. See https://vue-ssr-carousel.netlify.app/ui.
 - `show-dots` (`false`) - Whether to show dot style pagination dots. See https://vue-ssr-carousel.netlify.app/ui.
 

--- a/demo/components/layout/nav.vue
+++ b/demo/components/layout/nav.vue
@@ -20,6 +20,7 @@ export default
 		{ title: 'Gutters', path: '/gutters' }
 		{ title: 'UI', path: '/ui' }
 		{ title: 'Looping', path: '/looping' }
+		{ title: 'Peeking', path: '/peeking' }
 		{ title: 'Miscellaneous', path: '/misc' }
 	]
 

--- a/demo/components/slide.vue
+++ b/demo/components/slide.vue
@@ -3,6 +3,7 @@
 <template lang='pug'>
 
 .slide: div
+	.tint(v-if='tint' :style='{ background: tint }')
 	.title(v-if='index') Slide {{ index }}
 	slot
 
@@ -14,6 +15,7 @@
 export default
 	props:
 		index: Number
+		tint: String
 
 </script>
 
@@ -38,6 +40,15 @@ export default
 	fluid-space padding 's'
 	> div
 		width 100%
+
+	// Capture tint
+	position relative
+	overflow hidden
+
+// Optional tint layer, for easier tracking of cloning
+.tint
+	expand()
+	opacity 0.4
 
 // Increase slide text size
 .title

--- a/demo/content/looping.md
+++ b/demo/content/looping.md
@@ -6,14 +6,14 @@ title: 'Looping'
 
 Looping is also known as `wrapAround` or `infinite` in other carousels.
 
-<ssr-carousel :slides-per-page='1' loop show-dots show-arrows>
+<ssr-carousel loop show-dots show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' loop show-dots show-arrows>
+<ssr-carousel loop show-dots show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -42,7 +42,7 @@ Note how the incomplete 2nd page is handled.  The 3rd and 1st slide are shown si
 
 In this case, we're using [vue-visual](https://github.com/BKWLD/vue-visual) components to render image assets.  Note how lazy loading prevents the loading of the second image until you advance forward.
 
-<ssr-carousel :slides-per-page='1' loop>
+<ssr-carousel loop>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'
@@ -60,7 +60,7 @@ In this case, we're using [vue-visual](https://github.com/BKWLD/vue-visual) comp
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' loop>
+<ssr-carousel loop>
   <slide>
     <visual
       image='https://via.placeholder.com/1920x1080?text=Slide+1'

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -46,17 +46,19 @@ You should add `loop` when using a left peek so that space is filled on the firs
 
 Note how there is only one more slide than the amount we're showing per page. The last slide gets cloned so it peeks in on both the left and right sides.  This example also uses the `peek` shorthand that sets both `peek-left` and `peek-right` to the same value.
 
-<ssr-carousel loop :slides-per-page='2' paginate-by-slide peek-left='40' peek-right='40'>
-  <slide :index='1'></slide>
-  <slide :index='2'></slide>
-  <slide :index='3'></slide>
+<ssr-carousel loop :slides-per-page='3' peek-left='40' peek-right='40' show-arrows show-dots>
+  <slide :index='1' tint='red'></slide>
+  <slide :index='2' tint='orange'></slide>
+  <slide :index='3' tint='yellow'></slide>
+  <slide :index='4' tint='green'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel loop :slides-per-page='2' paginate-by-slide peek-left='40' peek-right='40'>
+<ssr-carousel loop :slides-per-page='3' peek-left='40' peek-right='40' show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
+  <slide :index='4'></slide>
 </ssr-carousel>
 ```
 
@@ -66,6 +68,7 @@ This example uses the `peek-gutters` sugar that automatically sets the peek valu
 
 <ssr-carousel
   :slides-per-page='2'
+  paginate-by-slide
   loop
   peek-left='10%'
   peek-right='10%'
@@ -85,6 +88,7 @@ This example uses the `peek-gutters` sugar that automatically sets the peek valu
 ```vue
 <ssr-carousel
   :slides-per-page='2'
+  paginate-by-slide
   loop
   peek-left='10%'
   peek-right='10%'

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -42,18 +42,60 @@ You should add `loop` when using a left peek so that space is filled on the firs
 </ssr-carousel>
 ```
 
-## Peeking with multiple slides per page
+## Slides are cloned as needed
 
-Note how there is only one more slide than the amount we're showing per page. The last slide gets cloned so it peeks in on both the left and right sides.
+Note how there is only one more slide than the amount we're showing per page. The last slide gets cloned so it peeks in on both the left and right sides.  This example also uses the `peek` shorthand that sets both `peek-left` and `peek-right` to the same value.
 
-<ssr-carousel loop :slides-per-page='2' peek-left='40' peek-right='40'>
+<ssr-carousel loop :slides-per-page='2' paginate-by-slide peek-left='40' peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel loop :slides-per-page='2' peek-left='40' peek-right='40'>
+<ssr-carousel loop :slides-per-page='2' paginate-by-slide peek-left='40' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>
+```
+
+## Peeking values are responsive and support CSS units
+
+This example uses the `peek-gutters` sugar that automatically sets the peek values to the same value as the `gutter`.
+
+<ssr-carousel
+  :slides-per-page='2'
+  loop
+  peek-left='10%'
+  peek-right='10%'
+  :responsive='[
+    {
+      maxWidth: 767,
+      gutter: 10,
+      peekLeft: 20,
+      peekRight: 20,
+    }
+  ]'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel
+  :slides-per-page='2'
+  loop
+  peek-left='10%'
+  peek-right='10%'
+  :responsive='[
+    {
+      maxWidth: 767,
+      gutter: 10,
+      peekLeft: 20,
+      peekRight: 20,
+    }
+  ]'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -6,16 +6,58 @@ title: 'Peeking'
 
 This is an example of implementing peeking on the right side only, which is useful for teasing the presence of other cards.
 
-<ssr-carousel :slides-per-page='1' peek-right='40'>
+<ssr-carousel :slides-per-page='2' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+</ssr-carousel>
+```
+
+## Peeking with loop
+
+You should add `loop` when using a left peek so that space is filled on the first page.
+
+<ssr-carousel loop peek-left='40' peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
 
 ```vue
-<ssr-carousel :slides-per-page='1' peek-right='40'>
+<ssr-carousel loop peek-left='40' peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
+</ssr-carousel>
+```
+
+## Peeking with multiple slides per page
+
+<ssr-carousel loop :slides-per-page='2' peek-left='40' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel loop :slides-per-page='2' peek-left='40' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
 </ssr-carousel>
 ```

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -44,12 +44,12 @@ You should add `loop` when using a left peek so that space is filled on the firs
 
 ## Peeking with multiple slides per page
 
+Note how there is only one more slide than the amount we're showing per page. The last slide gets cloned so it peeks in on both the left and right sides.
+
 <ssr-carousel loop :slides-per-page='2' peek-left='40' peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
-  <slide :index='4'></slide>
-  <slide :index='5'></slide>
 </ssr-carousel>
 
 ```vue
@@ -57,7 +57,5 @@ You should add `loop` when using a left peek so that space is filled on the firs
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
-  <slide :index='4'></slide>
-  <slide :index='5'></slide>
 </ssr-carousel>
 ```

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -4,6 +4,8 @@ title: 'Peeking'
 
 ## Basic peeking
 
+This is an example of implementing peeking on the right side only, which is useful for teasing the presence of other cards.
+
 <ssr-carousel :slides-per-page='1' peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -1,0 +1,19 @@
+---
+title: 'Peeking'
+---
+
+## Basic peeking
+
+<ssr-carousel :slides-per-page='1' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel :slides-per-page='1' peek-right='40'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+</ssr-carousel>
+```

--- a/demo/content/peeking.md
+++ b/demo/content/peeking.md
@@ -6,7 +6,7 @@ title: 'Peeking'
 
 This is an example of implementing peeking on the right side only, which is useful for teasing the presence of other cards.
 
-<ssr-carousel :slides-per-page='2' peek-right='40'>
+<ssr-carousel :slides-per-page='2' :peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -28,7 +28,7 @@ This is an example of implementing peeking on the right side only, which is usef
 
 You should add `loop` when using a left peek so that space is filled on the first page.
 
-<ssr-carousel loop peek-left='40' peek-right='40'>
+<ssr-carousel loop :peek-left='40' :peek-right='40'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -46,7 +46,7 @@ You should add `loop` when using a left peek so that space is filled on the firs
 
 Note how there is only one more slide than the amount we're showing per page. The last slide gets cloned so it peeks in on both the left and right sides.  This example also uses the `peek` shorthand that sets both `peek-left` and `peek-right` to the same value.
 
-<ssr-carousel loop :slides-per-page='3' peek-left='40' peek-right='40' show-arrows show-dots>
+<ssr-carousel loop :slides-per-page='3' :peek='40' show-arrows show-dots>
   <slide :index='1' tint='red'></slide>
   <slide :index='2' tint='orange'></slide>
   <slide :index='3' tint='yellow'></slide>
@@ -54,7 +54,7 @@ Note how there is only one more slide than the amount we're showing per page. Th
 </ssr-carousel>
 
 ```vue
-<ssr-carousel loop :slides-per-page='3' peek-left='40' peek-right='40' show-arrows>
+<ssr-carousel loop :slides-per-page='3' :peek='40' show-arrows>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
@@ -70,14 +70,12 @@ This example uses the `peek-gutters` sugar that automatically sets the peek valu
   :slides-per-page='2'
   paginate-by-slide
   loop
-  peek-left='10%'
-  peek-right='10%'
+  peek='10%'
   :responsive='[
     {
       maxWidth: 767,
       gutter: 10,
-      peekLeft: 20,
-      peekRight: 20,
+      peek: 20,
     }
   ]'>
   <slide :index='1'></slide>
@@ -90,18 +88,52 @@ This example uses the `peek-gutters` sugar that automatically sets the peek valu
   :slides-per-page='2'
   paginate-by-slide
   loop
-  peek-left='10%'
-  peek-right='10%'
+  peek='10%'
   :responsive='[
     {
       maxWidth: 767,
       gutter: 10,
-      peekLeft: 20,
-      peekRight: 20,
+      peek: 20,
     }
   ]'>
   <slide :index='1'></slide>
   <slide :index='2'></slide>
   <slide :index='3'></slide>
 </ssr-carousel>
+```
+
+## Sync with gutter setting
+
+The `peek-gutter` prop uses your gutter value for the prop.  This is useful setting when your `vue-ssr-carousel` instance is flush with the edges of your browser and you use your site gutter value; the slides will transition out the edge of the page.  Then, use the `min-feather-break` prop to automatically add a light feathering mask fade out exiting slides at large viewports.
+
+<ssr-carousel
+  :slides-per-page='3'
+  paginate-by-slide
+  loop
+  peek-gutter
+  gutter='var(--fluid-gutter)'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+</ssr-carousel>
+
+```vue
+<ssr-carousel
+  :slides-per-page='3'
+  paginate-by-slide
+  loop
+  peek-gutter
+  gutter='var(--fluid-gutter)'>
+  <slide :index='1'></slide>
+  <slide :index='2'></slide>
+  <slide :index='3'></slide>
+  <slide :index='4'></slide>
+  <slide :index='5'></slide>
+</ssr-carousel>
+<style lang="stylus">
+body
+  fluid --fluid-gutter, 40, 20
+</style>
 ```

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -26,6 +26,14 @@ export default
 		# Calculate the width of the track
 		trackWidth: -> @slideWidth * @slidesCount
 
+		# The ending x value
+		endX: ->
+			return 0 if @disabled
+			@pageWidth - @trackWidth
+
+		# Check if the drag is currently out bounds
+		isOutOfBounds: -> @currentX > 0 or @currentX < @endX
+
 	methods:
 
 		# Measure the component width for various calculations. Using

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -6,7 +6,7 @@ export default
 
 	data: ->
 		viewportWidth: null # Width of the viewport, for media query calculation
-		pageWidth: null # Width of a page of slides (aka the carousel container)
+		carouselWidth: null # Width of a page of the carousel
 		gutterWidth: 0 # Computed width of gutters, since they support css vars
 
 	# Add resize listening
@@ -20,21 +20,20 @@ export default
 
 	computed:
 
+		# The width of a page of slides, which may be less than the carouselWidth
+		# if there is peeking. This includes the affect of gutters.
+		pageWidth: -> @carouselWidth - @combinedPeek
+
 		# Calculate the width of a slide based on client side measured pageWidth
 		# rather than measuring it explicitly in the DOM. This value includes the
 		# gutter.
-		slideWidth: ->
-			@pageWidth / @currentSlidesPerPage -
-			@combinedPeek / @currentSlidesPerPage
+		slideWidth: -> @pageWidth  / @currentSlidesPerPage
 
 		# Calculate the width of the whole track from the slideWidth.
-		trackWidth: -> @slideWidth * @slidesCount
+		trackWidth: -> @slideWidth * @slidesCount - @peekRightPx
 
 		# The ending x value
-		endX: ->
-			return 0 if @disabled
-			@pageWidth - @trackWidth -
-			@combinedPeek * (@pages - 1) - @peekLeftPx # Inverse of track offset
+		endX: -> if @disabled then 0 else @pageWidth - @trackWidth
 
 		# Check if the drag is currently out bounds
 		isOutOfBounds: -> @currentX > 0 or @currentX < @endX
@@ -48,5 +47,5 @@ export default
 			return unless @$el?.nodeType == Node.ELEMENT_NODE
 			return unless firstSlide = @$refs.track.$el.firstElementChild
 			@gutterWidth = parseInt getComputedStyle(firstSlide).marginRight
-			@pageWidth = @$el.getBoundingClientRect().width + @gutterWidth
+			@carouselWidth = @$el.getBoundingClientRect().width + @gutterWidth
 			@viewportWidth = window.innerWidth

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -20,16 +20,21 @@ export default
 
 	computed:
 
-		# Calculate the width of a slide
-		slideWidth: -> @pageWidth / @currentSlidesPerPage
+		# Calculate the width of a slide based on client side measured pageWidth
+		# rather than measuring it explicitly in the DOM. This value includes the
+		# gutter.
+		slideWidth: ->
+			@pageWidth / @currentSlidesPerPage -
+			@combinedPeek / @currentSlidesPerPage
 
-		# Calculate the width of the track
+		# Calculate the width of the whole track from the slideWidth.
 		trackWidth: -> @slideWidth * @slidesCount
 
 		# The ending x value
 		endX: ->
 			return 0 if @disabled
-			@pageWidth - @trackWidth + @peekRightPx
+			@pageWidth - @trackWidth -
+			@combinedPeek * (@pages - 1) - @peekLeftPx # Inverse of track offset
 
 		# Check if the drag is currently out bounds
 		isOutOfBounds: -> @currentX > 0 or @currentX < @endX

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -29,7 +29,7 @@ export default
 		# The ending x value
 		endX: ->
 			return 0 if @disabled
-			@pageWidth - @trackWidth
+			@pageWidth - @trackWidth + @peekRightPx
 
 		# Check if the drag is currently out bounds
 		isOutOfBounds: -> @currentX > 0 or @currentX < @endX

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -1,0 +1,39 @@
+###
+Code related to measuring the size of the carousel after mounting
+###
+import throttle from 'lodash/throttle'
+export default
+
+	data: ->
+		viewportWidth: null # Width of the viewport, for media query calculation
+		pageWidth: null # Width of a page of slides (aka the carousel container)
+		gutterWidth: 0 # Computed width of gutters, since they support css vars
+
+	# Add resize listening
+	mounted: ->
+		@onResize()
+		@onResizeThrottled = throttle @onResize, 200
+		window.addEventListener 'resize', @onResizeThrottled
+
+	# Cleanup listeners
+	beforeDestroy: -> window.removeEventListener 'resize', @onResizeThrottled
+
+	computed:
+
+		# Calculate the width of a slide
+		slideWidth: -> @pageWidth / @currentSlidesPerPage
+
+		# Calculate the width of the track
+		trackWidth: -> @slideWidth * @slidesCount
+
+	methods:
+
+		# Measure the component width for various calculations. Using
+		# getBoundingClientRect so we can get fractional values.  We also need
+		# the width of the gutter since that's effectively part of the page.
+		onResize: ->
+			return unless @$el?.nodeType == Node.ELEMENT_NODE
+			return unless firstSlide = @$refs.track.$el.firstElementChild
+			@gutterWidth = parseInt getComputedStyle(firstSlide).marginRight
+			@pageWidth = @$el.getBoundingClientRect().width + @gutterWidth
+			@viewportWidth = window.innerWidth

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -49,3 +49,4 @@ export default
 			@gutterWidth = parseInt getComputedStyle(firstSlide).marginRight
 			@carouselWidth = @$el.getBoundingClientRect().width + @gutterWidth
 			@viewportWidth = window.innerWidth
+			@capturePeekingMeasurements()

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -27,13 +27,31 @@ export default
 		# Calculate the width of a slide based on client side measured pageWidth
 		# rather than measuring it explicitly in the DOM. This value includes the
 		# gutter.
-		slideWidth: -> @pageWidth  / @currentSlidesPerPage
+		slideWidth: -> @pageWidth / @currentSlidesPerPage
 
 		# Calculate the width of the whole track from the slideWidth.
-		trackWidth: -> @slideWidth * @slidesCount - @peekRightPx
+		trackWidth: -> @slideWidth * @slidesCount
 
-		# The ending x value
-		endX: -> if @disabled then 0 else @pageWidth - @trackWidth
+		# Figure out the width of the last page, which may not have enough slides
+		# to fill it.
+		lastPageWidth: ->
+
+			# Determine how many slides are on the final page of pagination. If the
+			# remainder was 0, that means the page is flush with slides, so swap
+			# the 0 for the max amount.
+			slidesPerPage = @currentSlidesPerPage
+			slidesOnLastPage = @slidesCount % slidesPerPage
+			if slidesOnLastPage == 0
+			then slidesOnLastPage = slidesPerPage
+
+			# Turn the slide count into a width value
+			width = slidesOnLastPage * @slideWidth
+			return width
+
+		# The ending x value, only used when not looping
+		endX: ->
+			if @disabled then 0
+			else @pageWidth - @trackWidth + @peekRightPx
 
 		# Check if the drag is currently out bounds
 		isOutOfBounds: -> @currentX > 0 or @currentX < @endX

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -57,12 +57,15 @@ export default
 
 		# Determine the current index given the currentX as a fraction. For
 		# instance, when dragging forward, it will be like 0.1 and when you've
-		# dragged almost a full page, forward it would be 0.9.
+		# dragged almost a full page, forward it would be 0.9. I'm using
+		# `trackWidth` as the base of my calculation because it takes into account
+		# the `peekRightPx`.
 		fractionalIndex: ->
 			x = @currentX - @currentIncompletePageOffset
-			if @paginateBySlide
-			then x / @slideWidth * -1
-			else x / @pageWidth * -1
+			trackPercent = x / @trackWidth
+			return if @paginateBySlide
+			then trackPercent * @slidesCount * -1
+			else trackPercent * @pages * -1
 
 		# Determine if the user is dragging vertically
 		isVerticalDrag: ->

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -64,12 +64,6 @@ export default
 			then x / @slideWidth * -1
 			else x / @pageWidth * -1
 
-		# Calculate the width of a slide
-		slideWidth: -> @pageWidth / @currentSlidesPerPage
-
-		# Calculate the width of the track
-		trackWidth: -> @slideWidth * @slidesCount
-
 		# The ending x value
 		endX: -> if @disabled then 0 else @pageWidth - @trackWidth
 

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -64,12 +64,6 @@ export default
 			then x / @slideWidth * -1
 			else x / @pageWidth * -1
 
-		# The ending x value
-		endX: -> if @disabled then 0 else @pageWidth - @trackWidth
-
-		# Check if the drag is currently out bounds
-		isOutOfBounds: -> @currentX > 0 or @currentX < @endX
-
 		# Determine if the user is dragging vertically
 		isVerticalDrag: ->
 			return unless @dragDirectionRatio

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -23,8 +23,9 @@ export default
 			remainder = slides.slice 0, count - prepended.length
 			slides = [ ...prepended, ...remainder ]
 
-			# Prepend the left peeking slide if it exists
-			slides = [ @leftPeekingSlide, ...slides] if @leftPeekingSlide
+			# Add cloned, peeking slides to the periphery
+			if @leftPeekingSlide and @rightPeekingSlide
+			then slides = [ @leftPeekingSlide, ...slides, @rightPeekingSlide]
 
 			# Return adjusted list of slides
 			slides
@@ -38,6 +39,6 @@ export default
 		# track transform so that the slides don't feel like they were re-ordered.
 		trackLoopOffset: ->
 			return 0 unless @loop
-			offsetIndex = @currentSlideIndex
-			offsetIndex -= 1 if @leftPeekingSlide
-			return offsetIndex * @slideWidth
+			offsetSlideCount = @currentSlideIndex
+			offsetSlideCount -= 1 if @leftPeekingSlide
+			return offsetSlideCount * @slideWidth

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -6,9 +6,6 @@ export default
 	# Add prop to enable looping
 	props: loop: Boolean
 
-	# Store cloned slides
-	data: -> clonedLastSlide: null
-
 	computed:
 
 		# Put slides in order, applying rules related to looping
@@ -27,36 +24,12 @@ export default
 		# This represents the current (as in while scrolling / animating) left most
 		# slide index. This is used in looping calculation so that the reordering
 		# of slides isn't affected by paginatePerSlide setting.
-		currentSlideIndex: -> Math.floor @currentX / @slideWidth * -1
+		currentSlideIndex: ->
+			console.log (@currentX - @currentIncompletePageOffset) / (@pageWidth / @currentSlidesPerPage) * -1
+			Math.floor @currentX / @slideWidth * -1
 
 		# When looping, slides get re-ordered. This value is added to the
 		# track transform so that the slides don't feel like they were re-ordered.
 		trackLoopOffset: ->
 			unless @loop then 0
 			else @currentSlideIndex * @slideWidth
-
-	methods:
-
-		# Clone a vnode, based on
-		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89
-		cloneVnode: (vnode) ->
-			cloned = new vnode.constructor(
-				vnode.tag,
-				vnode.data,
-				vnode.children && vnode.children.slice(),
-				vnode.text,
-				vnode.elm,
-				vnode.context,
-				vnode.componentOptions,
-				vnode.asyncFactory
-			)
-			cloned.ns = vnode.ns
-			cloned.isStatic = vnode.isStatic
-			cloned.key = vnode.key
-			cloned.isComment = vnode.isComment
-			cloned.fnContext = vnode.fnContext
-			cloned.fnOptions = vnode.fnOptions
-			cloned.fnScopeId = vnode.fnScopeId
-			cloned.asyncMeta = vnode.asyncMeta
-			cloned.isCloned = true
-			return cloned

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -10,26 +10,34 @@ export default
 
 		# Put slides in order, applying rules related to looping
 		slides: ->
+			slides = @slottedSlides
+			count = slides.length
 
 			# If not looping, don't show other slides during boundary dampening
-			return @slottedSlides unless @loop
+			return slides unless @loop
 
 			# Breakup the slides into arrays using the modulo of the current
 			# side index.  I came up with this by figuring out how the arrays should
 			# look and working back from there.
-			prepended = @slottedSlides.slice @currentSlideIndex % @slidesCount
-			remainder = @slottedSlides.slice 0, @slidesCount - prepended.length
-			return [ ...prepended, ...remainder ]
+			prepended = slides.slice @currentSlideIndex % count
+			remainder = slides.slice 0, count - prepended.length
+			slides = [ ...prepended, ...remainder ]
+
+			# Prepend the left peeking slide if it exists
+			slides = [ @leftPeekingSlide, ...slides] if @leftPeekingSlide
+
+			# Return adjusted list of slides
+			slides
 
 		# This represents the current (as in while scrolling / animating) left most
 		# slide index. This is used in looping calculation so that the reordering
 		# of slides isn't affected by paginatePerSlide setting.
-		currentSlideIndex: ->
-			console.log (@currentX - @currentIncompletePageOffset) / (@pageWidth / @currentSlidesPerPage) * -1
-			Math.floor @currentX / @slideWidth * -1
+		currentSlideIndex: -> Math.floor @currentX / @slideWidth * -1
 
 		# When looping, slides get re-ordered. This value is added to the
 		# track transform so that the slides don't feel like they were re-ordered.
 		trackLoopOffset: ->
-			unless @loop then 0
-			else @currentSlideIndex * @slideWidth
+			return 0 unless @loop
+			offsetIndex = @currentSlideIndex
+			offsetIndex -= 1 if @leftPeekingSlide
+			return offsetIndex * @slideWidth

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -21,8 +21,8 @@ export default
 			slides = @slideOrder.map (index) => @slottedSlides[index]
 
 			# Add cloned, peeking slides to the periphery
-			if @leftPeekingSlide and @rightPeekingSlide
-			then slides = [ @leftPeekingSlide, ...slides, @rightPeekingSlide]
+			slides = [ @leftPeekingSlide, ...slides, @rightPeekingSlide]
+			.filter (val) -> !!val # Remove empty peeking slides
 
 			# Return adjusted list of slides
 			slides

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -6,6 +6,9 @@ export default
 	# Add prop to enable looping
 	props: loop: Boolean
 
+	# Store cloned slides
+	data: -> clonedLastSlide: null
+
 	computed:
 
 		# Put slides in order, applying rules related to looping
@@ -31,3 +34,29 @@ export default
 		trackOffset: ->
 			unless @loop then 0
 			else @currentSlideIndex * @slideWidth
+
+	methods:
+
+		# Clone a vnode, based on
+		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89
+		cloneVnode: (vnode) ->
+			cloned = new vnode.constructor(
+				vnode.tag,
+				vnode.data,
+				vnode.children && vnode.children.slice(),
+				vnode.text,
+				vnode.elm,
+				vnode.context,
+				vnode.componentOptions,
+				vnode.asyncFactory
+			)
+			cloned.ns = vnode.ns
+			cloned.isStatic = vnode.isStatic
+			cloned.key = vnode.key
+			cloned.isComment = vnode.isComment
+			cloned.fnContext = vnode.fnContext
+			cloned.fnOptions = vnode.fnOptions
+			cloned.fnScopeId = vnode.fnScopeId
+			cloned.asyncMeta = vnode.asyncMeta
+			cloned.isCloned = true
+			return cloned

--- a/src/concerns/looping.coffee
+++ b/src/concerns/looping.coffee
@@ -31,7 +31,7 @@ export default
 
 		# When looping, slides get re-ordered. This value is added to the
 		# track transform so that the slides don't feel like they were re-ordered.
-		trackOffset: ->
+		trackLoopOffset: ->
 			unless @loop then 0
 			else @currentSlideIndex * @slideWidth
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -37,6 +37,11 @@ export default
 		# The current incomplete page offset
 		currentIncompletePageOffset: -> @makeIncompletePageOffset @index
 
+		# Combine the different factors that come together to determine the x
+		# transfrom of the track
+		trackTranslateX: ->
+			@currentX + @trackOffset
+
 	watch:
 
 		# Emit events on index change

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -82,12 +82,13 @@ export default
 
 		# Creates a px value to represent adjustments that should be made to
 		# account for incommplete pages of slides when looping is enabled. Like
-		# when there is 3 slotted slides and 2 slides per page.
+		# when there is 3 slotted slides and 2 slides per page and you have looped
+		# over to the 2nd page index of 0. The track needs to be shifted to the
+		# left by one slideWidth in this case.
 		makeIncompletePageOffset: (index) ->
 			return 0 unless @loop and not @paginateBySlide
-			Math.floor(index / @pages) *
-			(@slidesCount % @currentSlidesPerPage) *
-			@slideWidth
+			incompleteWidth = @pageWidth - @lastPageWidth
+			Math.floor(index / @pages) * incompleteWidth
 
 		# Apply boundaries to the index
 		applyIndexBoundaries: (index) ->

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -74,7 +74,7 @@ export default
 			@startTweening()
 
 		# Creates a px value to represent adjustments that should be made to
-		# account for incommplete pages of slides when looping is enbaled. Like
+		# account for incommplete pages of slides when looping is enabled. Like
 		# when there is 3 slotted slides and 2 slides per page.
 		makeIncompletePageOffset: (index) ->
 			return 0 unless @loop and not @paginateBySlide

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -37,11 +37,6 @@ export default
 		# The current incomplete page offset
 		currentIncompletePageOffset: -> @makeIncompletePageOffset @index
 
-		# Combine the different factors that come together to determine the x
-		# transfrom of the track
-		trackTranslateX: ->
-			@currentX + @trackLoopOffset
-
 	watch:
 
 		# Emit events on index change

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -16,9 +16,16 @@ export default
 	computed:
 
 		# The current number of pages
-		pages: ->
-			if @paginateBySlide
-			then Math.max 1, @slidesCount - @currentSlidesPerPage
+		pages: -> switch
+
+			# When looping and paginating per slide, make a dot per slide
+			when @paginateBySlide and @loop then @slidesCount
+
+			# Else, restrict pages so you the last slide is flush with right edge
+			when @paginateBySlide then @slidesCount - @currentSlidesPerPage + 1
+
+			# When not paginating by slide, the amount of pages is related to the
+			# current number of slides shown per page.
 			else Math.ceil @slidesCount / @currentSlidesPerPage
 
 		# Disable carousel-ness when there aren't enough slides

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -40,7 +40,7 @@ export default
 		# Combine the different factors that come together to determine the x
 		# transfrom of the track
 		trackTranslateX: ->
-			@currentX + @trackOffset
+			@currentX + @trackLoopOffset
 
 	watch:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -4,40 +4,29 @@ gutter space.
 ###
 export default
 
-	data: -> leftPeekingSlide: null
+	data: ->
+		leftPeekingSlide: null
+		rightPeekingSlide: null
 
 	props:
 
 		# Distinct left/right peeking values
-		peekLeft:
-			type: Number | String
-			default: -> 0
-		peekRight:
-			type: Number | String
-			default: -> 0
+		peekLeft: Number | String
+		peekRight: Number | String
 
 	data: ->
-		peekLeftPx: Number @peekLeft
-		peekRightPx: Number @peekRight
+		peekLeftPx: Number @peekLeft || 0
+		peekRightPx: Number @peekRight || 0
+
+	created: ->
+		return unless @loop
+		@leftPeekingSlide = @cloneVnode @slottedSlides[@slidesCount - 1]
+		@rightPeekingSlide = @cloneVnode @slottedSlides[0]
 
 	computed:
 
 		# Combine the peeking values, which is needed commonly
 		combinedPeek: -> @peekLeftPx + @peekRightPx
-
-		# Determine whether a clone of the last slide should be made
-		shouldCreateLeftPeekingSlide: -> not @disabled and @loop and @peekLeft
-
-	watch:
-
-		# Clone the last slide for prepending to slides list. Watching this
-		# property because it updates as user drags.
-		currentSlideIndex:
-			immediate: true
-			handler: (index) ->
-				return unless @shouldCreateLeftPeekingSlide
-				lastSlideVnode = @slottedSlides[@slidesCount - 1]
-				@leftPeekingSlide = @cloneVnode lastSlideVnode
 
 	methods:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -7,7 +7,18 @@ export default
 	props:
 
 		# Distinct left/right peeking values
-		peekLeft: Number | String
-		peekRight: Number | String
+		peekLeft:
+			type: Number | String
+			default: -> 0
+		peekRight:
+			type: Number | String
+			default: -> 0
 
+	data: ->
+		peekLeftPx: Number @peekLeft
+		peekRightPx: Number @peekRight
 
+	computed:
+
+		# Combine the peeking values, which is needed commonly
+		combinedPeek: -> @peekLeftPx + @peekRightPx

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -1,0 +1,13 @@
+###
+Code related to allowing edge slides to peek in from the side, including empty
+gutter space.
+###
+export default
+
+	props:
+
+		# Distinct left/right peeking values
+		peekLeft: Number | String
+		peekRight: Number | String
+
+

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -4,6 +4,8 @@ gutter space.
 ###
 export default
 
+	data: -> clonedLastSlide: null
+
 	props:
 
 		# Distinct left/right peeking values
@@ -22,3 +24,42 @@ export default
 
 		# Combine the peeking values, which is needed commonly
 		combinedPeek: -> @peekLeftPx + @peekRightPx
+
+		# Determine whether a clone of the last slide should be made
+		shouldCloneLastSlide: -> @loop and @peekLeft
+
+	watch:
+
+		# Clone the last slide for prepending to slides list. Watching this
+		# property because it updates as user drags.
+		currentSlideIndex:
+			immediate: true
+			handler: (index) ->
+				return unless @shouldCloneLastSlide
+				# console.log index
+
+	methods:
+
+		# Clone a vnode, based on
+		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89
+		cloneVnode: (vnode) ->
+			cloned = new vnode.constructor(
+				vnode.tag,
+				vnode.data,
+				vnode.children && vnode.children.slice(),
+				vnode.text,
+				vnode.elm,
+				vnode.context,
+				vnode.componentOptions,
+				vnode.asyncFactory
+			)
+			cloned.ns = vnode.ns
+			cloned.isStatic = vnode.isStatic
+			cloned.key = vnode.key
+			cloned.isComment = vnode.isComment
+			cloned.fnContext = vnode.fnContext
+			cloned.fnOptions = vnode.fnOptions
+			cloned.fnScopeId = vnode.fnScopeId
+			cloned.asyncMeta = vnode.asyncMeta
+			cloned.isCloned = true
+			return cloned

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -4,7 +4,7 @@ gutter space.
 ###
 export default
 
-	data: -> clonedLastSlide: null
+	data: -> leftPeekingSlide: null
 
 	props:
 
@@ -26,7 +26,7 @@ export default
 		combinedPeek: -> @peekLeftPx + @peekRightPx
 
 		# Determine whether a clone of the last slide should be made
-		shouldCloneLastSlide: -> @loop and @peekLeft
+		shouldCreateLeftPeekingSlide: -> @loop and @peekLeft
 
 	watch:
 
@@ -35,8 +35,9 @@ export default
 		currentSlideIndex:
 			immediate: true
 			handler: (index) ->
-				return unless @shouldCloneLastSlide
-				# console.log index
+				return unless @shouldCreateLeftPeekingSlide
+				lastSlideVnode = @slottedSlides[@slidesCount - 1]
+				@leftPeekingSlide = @cloneVnode lastSlideVnode
 
 	methods:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -22,12 +22,6 @@ export default
 		peekLeftPx: 0
 		peekRightPx: 0
 
-	# Make clones of slides for left and right
-	created: ->
-		return unless @loop and @slidesCount > 1
-		@leftPeekingSlide = @cloneVnode @slottedSlides[@slidesCount - 1]
-		@rightPeekingSlide = @cloneVnode @slottedSlides[0]
-
 	computed:
 
 		# Combine the peeking values, which is needed commonly
@@ -38,6 +32,18 @@ export default
 			breakpoint = @currentResponsiveBreakpoint
 			left: @autoUnit @getResponsiveValue 'peekLeft', breakpoint
 			right: @autoUnit @getResponsiveValue 'peekRight', breakpoint
+
+	watch:
+
+		# Clone the edge slides for merging into the slides array
+		slideOrder:
+			immediate: true
+			handler: ->
+				return unless @loop and @slidesCount > 1
+				firstSlide = @slottedSlides[@slideOrder[@slidesCount - 1]]
+				lastSlide = @slottedSlides[@slideOrder[0]]
+				@leftPeekingSlide = @cloneVnode firstSlide
+				@rightPeekingSlide = @cloneVnode lastSlide
 
 	methods:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -10,13 +10,26 @@ export default
 
 	props:
 
+		# Use gutter's as the peeking value
+		peekGutter: Boolean
+
+		# Set both peeking values at once
+		peek:
+			type: Number | String
+			default: ->
+
+				# Prevent subpixel rounding issues from causing a sliver of offscreen
+				# slide from peaking in.
+				unless @peekGutter then 0
+				else "calc(#{@gutter} - 1px)"
+
 		# Distinct left/right peeking values
 		peekLeft:
 			type: Number | String
-			default: 0
+			default: -> @peek
 		peekRight:
 			type: Number | String
-			default: 0
+			default: -> @peek
 
 	data: ->
 		peekLeftPx: 0

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -40,10 +40,12 @@ export default
 			immediate: true
 			handler: ->
 				return unless @loop and @slidesCount > 1
-				firstSlide = @slottedSlides[@slideOrder[@slidesCount - 1]]
-				lastSlide = @slottedSlides[@slideOrder[0]]
-				@leftPeekingSlide = @cloneVnode firstSlide
-				@rightPeekingSlide = @cloneVnode lastSlide
+				if @peekLeft
+					firstSlide = @slottedSlides[@slideOrder[@slidesCount - 1]]
+					@leftPeekingSlide = @cloneVnode firstSlide
+				if @peekRight
+					lastSlide = @slottedSlides[@slideOrder[0]]
+					@rightPeekingSlide = @cloneVnode lastSlide
 
 	methods:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -26,7 +26,7 @@ export default
 		combinedPeek: -> @peekLeftPx + @peekRightPx
 
 		# Determine whether a clone of the last slide should be made
-		shouldCreateLeftPeekingSlide: -> @loop and @peekLeft
+		shouldCreateLeftPeekingSlide: -> not @disabled and @loop and @peekLeft
 
 	watch:
 

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -11,12 +11,16 @@ export default
 	props:
 
 		# Distinct left/right peeking values
-		peekLeft: Number | String
-		peekRight: Number | String
+		peekLeft:
+			type: Number | String
+			default: -> 0
+		peekRight:
+			type: Number | String
+			default: -> 0
 
 	data: ->
-		peekLeftPx: Number @peekLeft || 0
-		peekRightPx: Number @peekRight || 0
+		peekLeftPx: Number @peekLeft
+		peekRightPx: Number @peekRight
 
 	created: ->
 		return unless @loop

--- a/src/concerns/peeking.coffee
+++ b/src/concerns/peeking.coffee
@@ -13,17 +13,18 @@ export default
 		# Distinct left/right peeking values
 		peekLeft:
 			type: Number | String
-			default: -> 0
+			default: 0
 		peekRight:
 			type: Number | String
-			default: -> 0
+			default: 0
 
 	data: ->
-		peekLeftPx: Number @peekLeft
-		peekRightPx: Number @peekRight
+		peekLeftPx: 0
+		peekRightPx: 0
 
+	# Make clones of slides for left and right
 	created: ->
-		return unless @loop
+		return unless @loop and @slidesCount > 1
 		@leftPeekingSlide = @cloneVnode @slottedSlides[@slidesCount - 1]
 		@rightPeekingSlide = @cloneVnode @slottedSlides[0]
 
@@ -32,7 +33,21 @@ export default
 		# Combine the peeking values, which is needed commonly
 		combinedPeek: -> @peekLeftPx + @peekRightPx
 
+		# Make the styles object for reading computed styles
+		peekStyles: ->
+			breakpoint = @currentResponsiveBreakpoint
+			left: @autoUnit @getResponsiveValue 'peekLeft', breakpoint
+			right: @autoUnit @getResponsiveValue 'peekRight', breakpoint
+
 	methods:
+
+		# Capture measurements of peeking values
+		capturePeekingMeasurements: ->
+			return unless @$refs.peekValues
+			@$nextTick -> # Wait for getResponsiveValue on @peekStyles
+				styles = getComputedStyle @$refs.peekValues
+				@peekLeftPx = parseInt styles.left
+				@peekRightPx = parseInt styles.right
 
 		# Clone a vnode, based on
 		# https://github.com/vuejs/vue/blob/23760b5c7a350484ef1eee18f8c615027a8a8ad9/src/core/vdom/vnode.js#L89

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -205,4 +205,4 @@ export default
 		# Add px unit to a value if numeric
 		autoUnit: (val) ->
 			return '0px' unless val
-			if String(val).match /^\d+$/ then "#{val}px" else val
+			if String(val).match /^[\d\-\.]+$/ then "#{val}px" else val

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -145,7 +145,7 @@ export default
 			slidesPerPage = @getResponsiveValue 'slidesPerPage', breakpoint
 			gutter = @getResponsiveValue 'gutter', breakpoint
 			peekLeft = @getResponsiveValue 'peekLeft', breakpoint
-			peekRight = @getResponsiveValue 'peekLeft', breakpoint
+			peekRight = @getResponsiveValue 'peekRight', breakpoint
 			"calc(
 				#{100 / slidesPerPage}% -
 				(#{@autoUnit(peekLeft)} + #{@autoUnit(peekRight)}) / #{slidesPerPage} -

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -123,9 +123,11 @@ export default
 			unless gutter then "width: #{widthPercentage}%;"
 
 			# Otherwise use a calc to adjust to accomodate gutter
-			else "width: calc(#{widthPercentage}% -
-				#{@autoUnit(@combinedPeek)} -
-				#{@autoUnit(gutter)} * #{slidesPerPage - 1} / #{slidesPerPage});"
+			else "width: calc(
+				#{widthPercentage}% -
+				#{@autoUnit(@combinedPeek)} / #{slidesPerPage} -
+				#{@autoUnit(gutter)} * #{slidesPerPage - 1} / #{slidesPerPage}
+			);"
 
 		# Apply gutters between slides via margins
 		makeBreakpointMarginStyle: (breakpoint) ->

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -110,7 +110,7 @@ export default
 				#{@scopeSelector} .ssr-carousel-dots { display: flex; }
 				"""
 
-		# Make the flex-basis style that gives a slide it's width given
+		# Make the width style that gives a slide it's width given
 		# slidesPerPage. Reduce this width by the gutter if present
 		makeBreakpointWidthStyle: (breakpoint) ->
 
@@ -120,10 +120,10 @@ export default
 
 			# If there is no gutter, then width is simply a percentage
 			widthPercentage = 100 / slidesPerPage
-			unless gutter then "flex-basis: #{widthPercentage}%;"
+			unless gutter then "width: #{widthPercentage}%;"
 
 			# Otherwise use a calc to adjust to accomodate gutter
-			else "flex-basis: calc( #{widthPercentage}% -
+			else "width: calc(#{widthPercentage}% -
 				#{@autoUnit(gutter)} *
 				#{slidesPerPage - 1} / #{slidesPerPage});"
 

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -124,8 +124,8 @@ export default
 
 			# Otherwise use a calc to adjust to accomodate gutter
 			else "width: calc(#{widthPercentage}% -
-				#{@autoUnit(gutter)} *
-				#{slidesPerPage - 1} / #{slidesPerPage});"
+				#{@autoUnit(@combinedPeek)} -
+				#{@autoUnit(gutter)} * #{slidesPerPage - 1} / #{slidesPerPage});"
 
 		# Apply gutters between slides via margins
 		makeBreakpointMarginStyle: (breakpoint) ->

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -169,7 +169,7 @@ export default
 		getResponsiveValue: (property, breakpoint) ->
 
 			# If this breakpoint has a value, use it
-			return val if val = breakpoint[property]
+			return val if (val = breakpoint[property])?
 
 			# If no responsive rules, use default
 			return @[property] unless @responsiveRules.length
@@ -178,7 +178,8 @@ export default
 			breakpointIndex = @responsiveRules.findIndex ({ maxWidth }) ->
 				maxWidth == breakpoint.maxWidth
 			unless breakpointIndex >= 0
-			then throw "Breakpoint missing: #{JSON.stringify(breakpoint)}"
+			then throw "Breakpoint missing for #{property} in
+				#{JSON.stringify(breakpoint)}"
 
 			# ... if it _wasn't_ the first entry, check if any preceeding breakpoints
 			# have this value set

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -43,7 +43,7 @@ export default
 		currentResponsiveBreakpoint: ->
 			if match = [...@responsiveRules].reverse().find ({ active }) -> active
 			then match # Return the matching rule
-			else { @slidesPerPage, @gutter } # Else return defaults
+			else { @slidesPerPage, @gutter, @peekLeft, @peekRight } # Defaults
 
 		# Make the scoping selecotr
 		scopeSelector: -> "[data-ssrc-id='#{@scopeId}']"

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -1,7 +1,6 @@
 ###
 Code related to changing the slides per page at different viewport widths
 ###
-import throttle from 'lodash/throttle'
 export default
 
 	props:
@@ -21,20 +20,6 @@ export default
 		responsive:
 			type: Array
 			default: -> []
-
-	data: ->
-		viewportWidth: null # Width of the viewport, for media query calculation
-		pageWidth: null # Width of a page of slides (and the carousel container)
-		gutterWidth: 0 # Computed width of gutters, since they support css vars
-
-	# Add resize listening
-	mounted: ->
-		@onResize()
-		@onResizeThrottled = throttle @onResize, 200
-		window.addEventListener 'resize', @onResizeThrottled
-
-	# Cleanup listeners
-	beforeDestroy: -> window.removeEventListener 'resize', @onResizeThrottled
 
 	computed:
 
@@ -83,16 +68,6 @@ export default
 		disabled: -> @goto(0) if @disabled
 
 	methods:
-
-		# Measure the component width for various calculations. Using
-		# getBoundingClientRect so we can get fractional values.  We also need
-		# the width of the gutter since that's effectively part of the page.
-		onResize: ->
-			return unless @$el?.nodeType == Node.ELEMENT_NODE
-			return unless firstSlide = @$refs.track.$el.firstElementChild
-			@gutterWidth = parseInt getComputedStyle(firstSlide).marginRight
-			@pageWidth = @$el.getBoundingClientRect().width + @gutterWidth
-			@viewportWidth = window.innerWidth
 
 		# Take an item form the responsive array and make a media query from it
 		makeMediaQuery: (breakpoint) ->

--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -14,7 +14,8 @@ export default
 	computed:
 
 		# Styles that are used to position the track
-		styles: -> transform: "translateX(#{@trackTranslateX}px)"
+		styles: ->
+			transform: "translateX(#{@trackTranslateX}px)" if @trackTranslateX
 
 	# Render the track and slotted slides
 	render: (create) ->

--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -8,14 +8,13 @@ export default
 
 	props:
 		dragging: Boolean
-		currentX: Number
-		trackOffset: Number
+		trackTranslateX: Number
 		slides: Array
 
 	computed:
 
 		# Styles that are used to position the track
-		styles: -> transform: "translateX(#{@currentX + @trackOffset}px)"
+		styles: -> transform: "translateX(#{@trackTranslateX}px)"
 
 	# Render the track and slotted slides
 	render: (create) ->

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -21,7 +21,7 @@
 			ssr-carousel-track(
 				ref='track'
 				:slides='slides'
-				v-bind='{ dragging, currentX, trackOffset }')
+				v-bind='{ dragging, trackTranslateX }')
 
 		//- Back / Next navigation
 		ssr-carousel-arrows(

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -98,8 +98,7 @@ export default
 		trackTranslateX: ->
 			@currentX + # The value from tweening or dragging
 			@trackLoopOffset + # Offset from re-ordering slides for looping
-			@peekLeftPx + # Offset slides for the left peek
-			@combinedPeek * @index # Increasing offset peek effect on each page
+			@peekLeftPx #+ # Offset slides for the left peek
 
 		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -94,11 +94,13 @@ export default
 	computed:
 
 		# Combine the different factors that come together to determine the x
-		# transfrom of the track
+		# transfrom of the track.  We don't return a value until the carousel
+		# width is measured since the calculation depends on that.
 		trackTranslateX: ->
+			return unless @carouselWidth and not @disabled
 			@currentX + # The value from tweening or dragging
 			@trackLoopOffset + # Offset from re-ordering slides for looping
-			(if @disabled then 0 else @peekLeftPx) # Offset slides for the left peek
+			@peekLeftPx # Offset slides for the left peek
 
 		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -93,6 +93,13 @@ export default
 
 	computed:
 
+		# Combine the different factors that come together to determine the x
+		# transfrom of the track
+		trackTranslateX: ->
+			@currentX +
+			@trackLoopOffset +
+			@combinedPeek * @index
+
 		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0
 

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -53,6 +53,7 @@ import SsrCarouselTrack from './ssr-carousel-track'
 
 # Concerns
 import autoplay from './concerns/autoplay'
+import dimensions from './concerns/dimensions'
 import dragging from './concerns/dragging'
 import focus from './concerns/focus'
 import looping from './concerns/looping'
@@ -68,6 +69,7 @@ export default
 	# Load concerns
 	mixins: [
 		autoplay
+		dimensions
 		dragging
 		focus
 		looping

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -78,8 +78,8 @@ export default
 		focus
 		looping
 		pagination
-		peeking
 		responsive
+		peeking # After `responsive` so prop can access `gutter` prop
 		tweening
 	]
 

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -57,6 +57,7 @@ import dragging from './concerns/dragging'
 import focus from './concerns/focus'
 import looping from './concerns/looping'
 import pagination from './concerns/pagination'
+import peeking from './concerns/peeking'
 import responsive from './concerns/responsive'
 import tweening from './concerns/tweening'
 
@@ -71,6 +72,7 @@ export default
 		focus
 		looping
 		pagination
+		peeking
 		responsive
 		tweening
 	]

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -12,6 +12,10 @@
 	//- positioning outside of carousel).
 	.ssr-carousel-slides
 
+		//- Render peeking styles to an element so their computed px values can be
+		//- measured
+		.ssr-peek-values(ref='peekValues' :style='peekStyles')
+
 		//- The overflow mask and drag target
 		.ssr-carousel-mask(
 			:class='{ pressing, disabled }'
@@ -130,6 +134,10 @@ export default
 // Posiition arrows relative to this
 .ssr-carousel-slides
 	position relative
+
+// Used to capture computed values
+.ssr-peek-values
+	position: absolute
 
 // Mask around slides
 .ssr-carousel-mask

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -98,7 +98,7 @@ export default
 		trackTranslateX: ->
 			@currentX + # The value from tweening or dragging
 			@trackLoopOffset + # Offset from re-ordering slides for looping
-			@peekLeftPx #+ # Offset slides for the left peek
+			(if @disabled then 0 else @peekLeftPx) # Offset slides for the left peek
 
 		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -96,9 +96,10 @@ export default
 		# Combine the different factors that come together to determine the x
 		# transfrom of the track
 		trackTranslateX: ->
-			@currentX +
-			@trackLoopOffset +
-			@combinedPeek * @index
+			@currentX + # The value from tweening or dragging
+			@trackLoopOffset + # Offset from re-ordering slides for looping
+			@peekLeftPx + # Offset slides for the left peek
+			@combinedPeek * @index # Increasing offset peek effect on each page
 
 		# Determine whether to create hover event bindings
 		watchesHover: -> @autoplayDelay > 0


### PR DESCRIPTION
- [x] Add base `peek-right` with integer / px values
  - [x] Fix index change that happens when on last page and you click on carousel
  - [x] Fix whatever broke example
- [x] Add base `peek-left` with integer / px values
  - [x] Fix layout change when JS inits
    - It's because, when peeking, I'm increasing the `currentSlideIndex` to force the last slide to get prepended which causes `trackLoopOffset` to need to be non-0 and to do _that_ it needs to use the `slideWidth`.  I wonder if switching to a responsive, css `order` approach like proposed in #32, if this could done w/o needing the calculated `slideWidth`...
    - I plan to set the initial transform of the track in SSG responsive styles to mach the calculated styles
  - [x] Fix missing right peek slide when animating initial left (into negative index) because the slide that should be displayed there is on the prepended part of array slice.
    - I plan to fix this by always prepending the cloned slide to the `slides`.  I'll make a computed property to trigger this behavior based on `loop && peekLeft`.  Then a watcher on one of the index values (maybe `currentSlideIndex?`) that creates the clone and stores it in data.  Hoping this will be sufficient for SSR.
    - With this change, I shouldn't need to have the `+ 1` in `currentSlideIndex
    - [x] Changed cloned instances as needed to fix case with 4 slides, 3 per page, and one 2nd page.  Cloning just the 1 and 4th slides doesn't cut it.
  - [x] Fix issue with loop calculation with high index values, like `8` when 2 slides per page, where left peeking slide disappears ... I think this is because the `currentSlideIndex` calculation doesn't adjust for the peeking width changes
    - I think I have some errors with how I'm using `currentIncompletePageOffset` that don't emerge until you are multiple pages in and rounding issues (`Math.floor`) presents itself.  ~~Where this is used in `dragging` I need to make it not dependent on the `index` ... it needs to be baked into the `fractionalIndex` so it's more real time.  And I need to do something similar as part of `currentSlideIndex` ... I think I need `makeIncompletePageOffset()` to not take an index as it's prop but maybe the `currentX`?  Maybe it's a computed prop based on `currentX`?~~
      - I ended up making pageWidth natively take into account peeking effects and everything kind of fell into place
  - [x] Fix pop in when scrolling forward
    - [x] Only create peeking cards if looping and peeking value set responsibly anywhere
      - Kinda wondering if we _really_ do need responsive support for this, like CSS vars / % values could have the same effect
- [x] Fix fatal error on gutters and responsive pages
  - I think my addition of peek related stuff to the responsive concern broke stuff
- [x] Support CSS units and custom properties as peek values
  - I think the general idea here will be to get the computed values of peek left and right client side for used once user starts interacting, but to initial values by passing the props directly to the responsive styles
- [x] Make peeking a responsive property
- [x] Fix bug with non-paginate-by-slide where it starts jumping too many pages at a time
  - I think it's dragging specific and, thus, probably `fractionalIndex` related
  - [x] Fix new issue with single slide per page
  - [x] Fix issue with `paginate-by-slide`
- [x] Add shared `peek` prop as shorthand for setting multiple peeking values at once
- [x] Add `peek-gutters` prop as boolean sugar for setting the peaking to the value of the gutter

Closes #21, #15