### PR TITLE
Fix Change Event in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 
 See https://vue-ssr-carousel.netlify.app/events
 
-- `change({ index })` - Fired when the internal index counter changes
+- `change({ boundedIndex })` - Fired when the internal index counter changes
 - `press` - Fired on mouse or touch down
 - `release` - Fired on mouse or touch up
 - `drag:start` - Fired on start of dragging

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 
 See https://vue-ssr-carousel.netlify.app/events
 
-- `change({ boundedIndex })` - Fired when the internal index counter changes
+- `change({ index })` - Fired when the internal index counter changes
 - `press` - Fired on mouse or touch down
 - `release` - Fired on mouse or touch up
 - `drag:start` - Fired on start of dragging

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -47,7 +47,7 @@ export default
 	watch:
 
 		# Emit events on index change
-		boundedIndex: -> @$emit 'change', { @boundedIndex }
+		boundedIndex: -> @$emit 'change', index: @boundedIndex
 
 	methods:
 


### PR DESCRIPTION
Change event said the property used for `change` events was `index` but it was using `boundedIndex`