### PR TITLE
Support flexible width slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 
 | **Props**           | **Default** | **Description**
 |---------------------|-------------|----------------
-| `slides-per-page`   | `1`         | How many slides are shown per page.
+| `slides-per-page`   | `1`         | How many slides are shown per page. Can be set to `null` to allow for flexible widths for slides. See https://vue-ssr-carousel.netlify.app/responsive and note the caveats mentiond within.
 | `gutter`            | `20`        | The size of the space between slides. This can a number or any CSS resolvable string. See https://vue-ssr-carousel.netlify.app/gutters.
 | `paginate-by-slide` | `false`     | When `false`, dragging the carousel or interacting with the arrows will advance a full page of slides at a time.  When `true`, the carousel will come to a rest at each slide.
 | `loop`              | `false`     | Boolean to enable looping / infinite scroll. See https://vue-ssr-carousel.netlify.app/looping.
@@ -58,6 +58,7 @@ For more examples, see the demo: https://vue-ssr-carousel.netlify.app.
 | `overflow-visible`  | `false`     | Disables the `overflow:hidden` that wraps the slide track.  You would do this if you want to handle that masking in an ancestor element.  See https://vue-ssr-carousel.netlify.app/peeking.
 | `show-arrows`       | `false`     | Whether to show back/forward arrows. See https://vue-ssr-carousel.netlify.app/ui.
 | `show-dots`         | `false`     | Whether to show dot style pagination dots. See https://vue-ssr-carousel.netlify.app/ui.
+| `value`             | `undefined` | Used as part of `v-model` to set the initial slide to show.  See https://vue-ssr-carousel.netlify.app/events.
 | `responsive`        | `[]`        | Adjust settings at breakpoints. See https://vue-ssr-carousel.netlify.app/responsive. Note, `loop` and `paginate-by-slide` cannot be set responsively.
 
 ### Slots
@@ -87,10 +88,11 @@ See https://vue-ssr-carousel.netlify.app/events
 
 | Events                   | Description
 |--------------------------|--------------------------------------------------------------------
-| `change({ index })`      | Fired when the internal index counter changes
-| `press`                  | Fired on mouse or touch down
-| `release`                | Fired on mouse or touch up
-| `drag:start`             | Fired on start of dragging
-| `drag:end`               | Fired on end of dragging
-| `tween:start({ index })` | Fired when the carousel starts tweening to it's final position
+| `change({ index })`      | Fired when the internal index counter changes.
+| `input`                  | Same as `change` but intended for use with `v-model`.
+| `press`                  | Fired on mouse or touch down.
+| `release`                | Fired on mouse or touch up.
+| `drag:start`             | Fired on start of dragging.
+| `drag:end`               | Fired on end of dragging.
+| `tween:start({ index })` | Fired when the carousel starts tweening to it's final position.
 | `tween:end({ index })`   | Fired when the carousel has finished tweening to it's destination.

--- a/cypress/e2e/responsive.coffee
+++ b/cypress/e2e/responsive.coffee
@@ -1,4 +1,4 @@
-describe 'introduction', ->
+context 'responsive', ->
 
 	beforeEach -> cy.visit '/responsive'
 
@@ -60,3 +60,19 @@ describe 'introduction', ->
 				.slideHidden 2
 				.slideHidden 3
 				.pages 6
+
+	context 'variable width', ->
+
+		it 'can be dragged', ->
+			cy.get('[data-cy=variable-width]').within ->
+				cy.dragLeft().slideVisible 3
+
+		it "can't be dragged past last slide", ->
+			cy.get('[data-cy=variable-width]').within ->
+				cy.dragLeft().dragLeft()
+				cy.root().trackAtEnd()
+
+		it 'can be disabled', ->
+			cy.get('[data-cy=variable-width-disabled]').within ->
+				cy.get '.ssr-carousel-mask'
+					.should 'have.class', 'disabled'

--- a/cypress/support/commands/pagination.coffee
+++ b/cypress/support/commands/pagination.coffee
@@ -20,3 +20,26 @@ Cypress.Commands.add 'page', (num) ->
 Cypress.Commands.add 'pages', (num) ->
 	cy.get '[aria-live]'
 	.should 'contain', " of #{num}"
+
+# Confirm that track is at the end position by inspecting the CSS
+Cypress.Commands.add 'trackAtEnd', { prevSubject: true }, (subject) ->
+
+	# Get the carousel width
+	cy.wrap subject
+	.its '0.offsetWidth'
+	.then (carouselWidth) ->
+
+		# Get the track width
+		cy.wrap subject
+		.get '.ssr-carousel-track'
+		.its '0.scrollWidth'
+		.then (trackWidth) ->
+
+			# Calculate what we expect the transform to be
+			expectedTranslateX = Math.round carouselWidth - trackWidth + 1
+
+			# Asset that the transform value should match math related to those two
+			cy.wrap subject
+			.get '.ssr-carousel-track'
+			.should 'have.attr', 'style'
+			.should 'include', "translateX(#{expectedTranslateX}px)"

--- a/demo/assets/defaults.styl
+++ b/demo/assets/defaults.styl
@@ -7,11 +7,9 @@ body
 	// Disable outline on touch
 	-webkit-tap-highlight-color rgba(0,0,0,0)
 
-// Clear list styling by default (let it be reset in .wysiwyg)
+// Adjust list styling
 ul, ol
-	list-style none
-	padding-left 0
-	margin 0
+	padding-left 1.2em
 
 // Give all buttons a cursor style
 button

--- a/demo/components/demos/responsive/variable-width-disabled.vue
+++ b/demo/components/demos/responsive/variable-width-disabled.vue
@@ -1,0 +1,8 @@
+<template>
+
+<ssr-carousel :slides-per-page='null'>
+  <slide :index='1' :style='{ width: "30vw", height: "300px"}'></slide>
+  <slide :index='2' :style='{ width: "50vw", height: "300px"}'></slide>
+</ssr-carousel>
+
+</template>

--- a/demo/components/demos/responsive/variable-width-disabled.vue
+++ b/demo/components/demos/responsive/variable-width-disabled.vue
@@ -1,6 +1,8 @@
 <template>
 
-<ssr-carousel :slides-per-page='null'>
+<ssr-carousel
+	data-cy='variable-width-disabled'
+	:slides-per-page='null'>
   <slide :index='1' :style='{ width: "40%", height: "20vw"}'></slide>
   <slide :index='2' :style='{ width: "calc(60% - 20px)", height: "20vw"}'></slide>
 </ssr-carousel>

--- a/demo/components/demos/responsive/variable-width-disabled.vue
+++ b/demo/components/demos/responsive/variable-width-disabled.vue
@@ -1,8 +1,8 @@
 <template>
 
 <ssr-carousel :slides-per-page='null'>
-  <slide :index='1' :style='{ width: "30vw", height: "300px"}'></slide>
-  <slide :index='2' :style='{ width: "50vw", height: "300px"}'></slide>
+  <slide :index='1' :style='{ width: "40%", height: "20vw"}'></slide>
+  <slide :index='2' :style='{ width: "calc(60% - 20px)", height: "20vw"}'></slide>
 </ssr-carousel>
 
 </template>

--- a/demo/components/demos/responsive/variable-width.vue
+++ b/demo/components/demos/responsive/variable-width.vue
@@ -1,9 +1,11 @@
 <template>
 
-<ssr-carousel :slides-per-page='null'>
-  <slide :index='1' :style='{ width: "60vw", height: "400px"}'></slide>
-  <slide :index='2' :style='{ width: "40vw", height: "400px"}'></slide>
-  <slide :index='3' :style='{ width: "20vw", height: "400px"}'></slide>
+<ssr-carousel
+	data-cy='variable-width'
+	:slides-per-page='null'>
+  <slide :index='1' :style='{ width: "65%", height: "30vw"}'></slide>
+  <slide :index='2' :style='{ width: "50%", height: "30vw"}'></slide>
+  <slide :index='3' :style='{ width: "30%", height: "30vw"}'></slide>
 </ssr-carousel>
 
 </template>

--- a/demo/components/demos/responsive/variable-width.vue
+++ b/demo/components/demos/responsive/variable-width.vue
@@ -1,0 +1,9 @@
+<template>
+
+<ssr-carousel :slides-per-page='null'>
+  <slide :index='1' :style='{ width: "60vw", height: "400px"}'></slide>
+  <slide :index='2' :style='{ width: "40vw", height: "400px"}'></slide>
+  <slide :index='3' :style='{ width: "20vw", height: "400px"}'></slide>
+</ssr-carousel>
+
+</template>

--- a/demo/content/responsive.md
+++ b/demo/content/responsive.md
@@ -70,24 +70,25 @@ While it's not the primary use case of this package, you if you set `slidesPerPa
 
 - If there are not enough slides to fill the viewport, slides will be left aligned rather than center aligned.
 - This hasn't been tested with responsive props or looping. Peeking doesn't make sense for this use case but care hasn't been taken to disabling it.
+- Pagination controls aren't supported yet, this is purely drag only.
 
 <demos-responsive-variable-width></demos-responsive-variable-width>
 
 ```vue
 <ssr-carousel :slides-per-page='null'>
-  <slide :index='1' :style='{ width: "60vw", height: "400px"}'></slide>
-  <slide :index='2' :style='{ width: "40vw", height: "400px"}'></slide>
-  <slide :index='3' :style='{ width: "20vw", height: "400px"}'></slide>
+  <slide :index='1' :style='{ width: "65%", height: "30vw"}'></slide>
+  <slide :index='2' :style='{ width: "50%", height: "30vw"}'></slide>
+  <slide :index='3' :style='{ width: "30%", height: "30vw"}'></slide>
 </ssr-carousel>
 ```
 
-Here's an example where there aren't enough slides to fill the viewport:
+Here's an example where there aren't enough slides to exceed the carouel width:
 
 <demos-responsive-variable-width-disabled></demos-responsive-variable-width-disabled>
 
 ```vue
 <ssr-carousel :slides-per-page='null'>
-  <slide :index='1' :style='{ width: "30vw", height: "300px"}'></slide>
-  <slide :index='2' :style='{ width: "50vw", height: "300px"}'></slide>
+  <slide :index='1' :style='{ width: "40%", height: "20vw"}'></slide>
+  <slide :index='2' :style='{ width: "calc(60% - 20px)", height: "20vw"}'></slide>
 </ssr-carousel>
 ```

--- a/demo/content/responsive.md
+++ b/demo/content/responsive.md
@@ -4,6 +4,8 @@ title: 'Responsive Options'
 
 ## Change settings at different breakpoints
 
+You can use `max-width` rules:
+
 <demos-responsive-max-width></demos-responsive-max-width>
 
 ```vue
@@ -36,7 +38,7 @@ title: 'Responsive Options'
 </ssr-carousel>
 ```
 
-## Min-width queries are also supported
+... or `min-width` rules:
 
 <demos-responsive-min-width></demos-responsive-min-width>
 
@@ -59,5 +61,33 @@ title: 'Responsive Options'
   <slide :index='4'></slide>
   <slide :index='5'></slide>
   <slide :index='6'></slide>
+</ssr-carousel>
+```
+
+## Variable width slides (Experimental)
+
+While it's not the primary use case of this package, you if you set `slidesPerPage` to `null`, the carousel will not touch the width of individual slides.  Some notes:
+
+- If there are not enough slides to fill the viewport, slides will be left aligned rather than center aligned
+- The peeking props don't really make sense in this context and will be ignored.
+
+<demos-responsive-variable-width></demos-responsive-variable-width>
+
+```vue
+<ssr-carousel :slides-per-page='null'>
+  <slide :index='1' :style='{ width: "60vw", height: "400px"}'></slide>
+  <slide :index='2' :style='{ width: "40vw", height: "400px"}'></slide>
+  <slide :index='3' :style='{ width: "20vw", height: "400px"}'></slide>
+</ssr-carousel>
+```
+
+Here's an example where there aren't enough slides to fill the viewport:
+
+<demos-responsive-variable-width-disabled></demos-responsive-variable-width-disabled>
+
+```vue
+<ssr-carousel :slides-per-page='null'>
+  <slide :index='1' :style='{ width: "30vw", height: "300px"}'></slide>
+  <slide :index='2' :style='{ width: "50vw", height: "300px"}'></slide>
 </ssr-carousel>
 ```

--- a/demo/content/responsive.md
+++ b/demo/content/responsive.md
@@ -64,12 +64,12 @@ You can use `max-width` rules:
 </ssr-carousel>
 ```
 
-## Variable width slides (Experimental)
+## Variable width slides (beta)
 
 While it's not the primary use case of this package, you if you set `slidesPerPage` to `null`, the carousel will not touch the width of individual slides.  Some notes:
 
-- If there are not enough slides to fill the viewport, slides will be left aligned rather than center aligned
-- The peeking props don't really make sense in this context and will be ignored.
+- If there are not enough slides to fill the viewport, slides will be left aligned rather than center aligned.
+- This hasn't been tested with responsive props or looping. Peeking doesn't make sense for this use case but care hasn't been taken to disabling it.
 
 <demos-responsive-variable-width></demos-responsive-variable-width>
 

--- a/demo/pages/_page.vue
+++ b/demo/pages/_page.vue
@@ -96,7 +96,7 @@ h2
 	line-height 1.2
 
 // Style body text, like notes
-p
+p, ul
 	line-height 1.5
 	color lighten(primary-background, 50%)
 

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -30,7 +30,10 @@ export default
 		slideWidth: -> @pageWidth / @currentSlidesPerPage
 
 		# Calculate the width of the whole track from the slideWidth.
-		trackWidth: -> @slideWidth * @slidesCount
+		trackWidth: ->
+			if @isVariableWidth
+			then @measuredTrackWidth + @gutterWidth
+			else @slideWidth * @slidesCount
 
 		# Figure out the width of the last page, which may not have enough slides
 		# to fill it.
@@ -71,10 +74,12 @@ export default
 			@carouselWidth = @$el.getBoundingClientRect().width + @gutterWidth
 			@viewportWidth = window.innerWidth
 			@capturePeekingMeasurements()
+			@captureTrackWidth() if @isVariableWidth
 
 		# Make the width style that gives a slide it's width given
 		# slidesPerPage. Reduce this width by the gutter if present
 		makeBreakpointSlideWidthStyle: (breakpoint) ->
+			return if @isVariableWidth
 			"""
 			#{@scopeSelector} .ssr-carousel-slide {
 				width: #{@makeSlideWidthCalc(breakpoint)};

--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -132,8 +132,11 @@ export default
 
 				# Tween so the track is in bounds if it was out
 				if @isOutOfBounds and not @shouldLoop
-					if @currentX >= 0 then @goto 0
-					else @goto @pages - 1
+					if @currentX >= 0 then @gotoStart()
+					else @gotoEnd()
+
+				# If rendering variable width slides, don't come to a rest at an index
+				else if @isVariableWidth then @tweenToStop()
 
 				# If user was vertically dragging, reset the index
 				else if @isVerticalDrag then @goto @index

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -34,7 +34,10 @@ export default
 			else Math.ceil @slidesCount / @currentSlidesPerPage
 
 		# Disable carousel-ness when there aren't enough slides
-		disabled: -> @slidesCount <= @currentSlidesPerPage
+		disabled: ->
+			if @isVariableWidth
+			then @trackWidth <= @carouselWidth
+			else @slidesCount <= @currentSlidesPerPage
 
 		# Get just the slotted slides that are components, ignoring text nodes
 		# which may exist as a result of whitespace

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -36,7 +36,7 @@ export default
 		# Disable carousel-ness when there aren't enough slides
 		disabled: ->
 			if @isVariableWidth
-			then @trackWidth <= @carouselWidth
+			then Math.round(@trackWidth) <= Math.round(@carouselWidth)
 			else @slidesCount <= @currentSlidesPerPage
 
 		# Get just the slotted slides that are components, ignoring text nodes

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -106,6 +106,18 @@ export default
 			@index = @applyIndexBoundaries index
 			@tweenToIndex @index
 
+		# Go to the beginning of track
+		gotoStart: ->
+			if @isVariableWidth
+			then @tweenToX 0
+			else @goto 0
+
+		# Go to the end of the track
+		gotoEnd: ->
+			if @isVariableWidth
+			then @tweenToX @endX
+			else @goto @pages - 1
+
 		# Tween to a specific index
 		tweenToIndex: (index) ->
 

--- a/src/concerns/tweening.coffee
+++ b/src/concerns/tweening.coffee
@@ -11,6 +11,11 @@ export default
 			type: Number
 			default: 0.12
 
+		# A multiplier that is applied to the dragVelocity when using tweenToStop
+		tweenInertia:
+			type: Number
+			default: 3
+
 	data: ->
 		currentX: 0 # The actual left offset of the slides container
 		targetX: 0 # Where we may be tweening the slide to
@@ -62,4 +67,6 @@ export default
 			else @rafId = window.requestAnimationFrame @tweenToTarget
 
 		# Tween to stop based on inertia
-		tweenToStop: -> console.log 'tweenToStop'
+		tweenToStop: ->
+			@targetX = @applyXBoundaries @currentX + @dragVelocity * @tweenInertia
+			@startTweening()

--- a/src/concerns/tweening.coffee
+++ b/src/concerns/tweening.coffee
@@ -40,7 +40,9 @@ export default
 	methods:
 
 		# Convenience method to tween to a targetX
-		tweenToX: (@targetX)-> @startTweening()
+		tweenToX: (x)->
+			@targetX = Math.round x
+			@startTweening()
 
 		# Start tweening to target location if necessary and if not already
 		# tweening

--- a/src/concerns/tweening.coffee
+++ b/src/concerns/tweening.coffee
@@ -34,6 +34,9 @@ export default
 
 	methods:
 
+		# Convenience method to tween to a targetX
+		tweenToX: (@targetX)-> @startTweening()
+
 		# Start tweening to target location if necessary and if not already
 		# tweening
 		startTweening: ->
@@ -57,3 +60,6 @@ export default
 				@currentX = @targetX
 				@tweening = false
 			else @rafId = window.requestAnimationFrame @tweenToTarget
+
+		# Tween to stop based on inertia
+		tweenToStop: -> console.log 'tweenToStop'

--- a/src/concerns/variable-width.coffee
+++ b/src/concerns/variable-width.coffee
@@ -1,0 +1,18 @@
+###
+Functionality related to supporting variable width slides
+###
+export default
+
+	data: -> measuredTrackWidth: 0
+
+	computed:
+
+		# Is the carousel in variable width mode
+		isVariableWidth: -> @slidesPerPage == null
+
+	methods:
+
+		# Measure the width of the track
+		captureTrackWidth: ->
+			return unless @$refs.track
+			@measuredTrackWidth = @$refs.track.$el.scrollWidth

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -88,6 +88,7 @@ import pagination from './concerns/pagination'
 import peeking from './concerns/peeking'
 import responsive from './concerns/responsive'
 import tweening from './concerns/tweening'
+import variableWidth from './concerns/variable-width'
 
 # Component definition
 export default
@@ -107,6 +108,7 @@ export default
 		responsive
 		peeking # After `responsive` so prop can access `gutter` prop
 		tweening
+		variableWidth
 	]
 
 	components: {


### PR DESCRIPTION
- [x] Fix initial indented state when would be disabled
  - I think I need to improve the disabled detection
- [x] Fix endX value
  - I think I need to remove the final gutter margin-right or something
  - [x] Implement test of dragging to the endX
  - [x] Implement a test that dragging is allowed, that like you can reveal the 3rd slide
- [x] Implement `tweenToStop()`
  - Should apply bounding automatically, like just ease to a stop at bounds 
- [x] Ensure SSR rendering is good
- [x] Make sure disabling works properly and reacts to resizing window
  - [x] Make test that it can't be dragged ... like that the transform never changes on the track, maybe ... or maybe check for the disabled class, that'd be easier ... i think there is one

Closes #70 