### PR TITLE
Remove throttling of resizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
 	},
 	"homepage": "https://github.com/BKWLD/vue-ssr-carousel#readme",
 	"dependencies": {
-		"bukwild-stylus-library": "^3.1.0",
-		"lodash": "3 - 4"
+		"bukwild-stylus-library": "^3.1.0"
 	},
 	"devDependencies": {
 		"@cloak-app/boilerplate": "^1.0.8",

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -1,7 +1,6 @@
 ###
 Code related to measuring the size of the carousel after mounting
 ###
-import throttle from 'lodash/throttle'
 export default
 
 	data: ->
@@ -12,11 +11,10 @@ export default
 	# Add resize listening
 	mounted: ->
 		@onResize()
-		@onResizeThrottled = throttle @onResize, 200
-		window.addEventListener 'resize', @onResizeThrottled
+		window.addEventListener 'resize', @onResize
 
 	# Cleanup listeners
-	beforeDestroy: -> window.removeEventListener 'resize', @onResizeThrottled
+	beforeDestroy: -> window.removeEventListener 'resize', @onResize
 
 	computed:
 

--- a/src/concerns/pagination.coffee
+++ b/src/concerns/pagination.coffee
@@ -127,6 +127,15 @@ export default
 
 		# Tween to a specific index
 		tweenToIndex: (index) ->
+			@targetX = @getXForIndex index
+			@startTweening()
+
+		# Jump to an index with no tween
+		jumpToIndex: (index) ->
+			@currentX = @targetX = @getXForIndex index
+
+		# Calculate the X value given an index
+		getXForIndex: (index) ->
 
 			# Figure out the new x position
 			x = if @paginateBySlide
@@ -135,10 +144,7 @@ export default
 
 			# Apply adjustments to x value and persist
 			x += @makeIncompletePageOffset index
-			@targetX = Math.round @applyXBoundaries x
-
-			# Start tweening
-			@startTweening()
+			return Math.round @applyXBoundaries x
 
 		# Creates a px value to represent adjustments that should be made to
 		# account for incommplete pages of slides when looping is enabled. Like

--- a/src/concerns/responsive.coffee
+++ b/src/concerns/responsive.coffee
@@ -69,7 +69,7 @@ export default
 	watch:
 
 		# Fix alignment of slides while resizing
-		pageWidth: -> @tweenToIndex @index
+		pageWidth: -> @jumpToIndex @index
 
 		# If resizing the browser leads to disabling, reset the slide to the first
 		# page.  Like if a user had switched to the 2nd page on mobile and then

--- a/yarn.lock
+++ b/yarn.lock
@@ -7142,7 +7142,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-"lodash@3 - 4", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.5:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
I’m counting on the calculation not being *that* heavy and it makes it so there isn’t a weird tweening when resizing the browser window.  Also lets us lose lodash dependency.

Closes #108 