### PR TITLE
Add option to render the carousel track as an unordered list

### DIFF
--- a/src/ssr-carousel-track.vue
+++ b/src/ssr-carousel-track.vue
@@ -11,6 +11,7 @@ export default
 		activeSlides: Array
 		leftPeekingSlideIndex: Number
 		rightPeekingSlideIndex: Number
+		renderAsList: Boolean
 
 	# Set tabindex of inactive slides on mount
 	mounted: ->
@@ -18,6 +19,8 @@ export default
 		@denyTabindex @clonedSlides
 
 	computed:
+		# The HTML element of the track
+		trackHTMLElement: -> if @renderAsList then 'ul' else 'div'
 
 		# Get the count of non-cloned slides
 		uniqueSlidesCount: -> @slideOrder.length
@@ -144,7 +147,7 @@ export default
 
 	# Render the track and slotted slides
 	render: (create) ->
-		create 'div',
+		create @trackHTMLElement,
 			class: [ 'ssr-carousel-track', { @dragging } ]
 			style: @styles
 		, @makeSlides()

--- a/src/ssr-carousel.vue
+++ b/src/ssr-carousel.vue
@@ -41,6 +41,7 @@
 					activeSlides,
 					leftPeekingSlideIndex,
 					rightPeekingSlideIndex,
+					renderAsList
 				}`)
 
 				//- Render the slotted slides
@@ -127,6 +128,9 @@ export default
 		# UI enabling controls
 		showArrows: Boolean
 		showDots: Boolean
+
+		# Render carousel as a list
+		renderAsList: Boolean
 
 	computed:
 


### PR DESCRIPTION
This is a change requested as part of the HFO ADA audit made by Level Access. 

On the page https://www.happyfamilyorganics.com/our-story/ we have a button carousel that is used to navigate between the tabs of a block, and Level Access wrote the following about it: 

_The below-mentioned textual links below "Take a Journey Through Our Story" heading text visually appear as list items but are not marked using HTML list markup. When links are properly grouped, it facilitates labeling the group, skipping past the group, and helps to divide large blocks of information into more manageable components.

Following instances are affected:
- 2003
- 2006
- 2007-2008, etc.

[User Impact]
Screen reader users will benefit if the content has been structured using list markup._

This small change should provide a better user experience for screen reader users. 