### PR TITLE
ResizeObserver

### DIFF
--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -19,8 +19,7 @@ export default
 		@resizeObserver.observe @$el
 
 	beforeDestroy: ->
-		if @$el then @resizeObserver.unobserve(@$el)
-		else @resizeObserver.disconnect()
+		@resizeObserver?.disconnect()
 
 	computed:
 

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -7,14 +7,20 @@ export default
 		viewportWidth: null # Width of the viewport, for media query calculation
 		carouselWidth: null # Width of a page of the carousel
 		gutterWidth: 0 # Computed width of gutters, since they support css vars
+		resizeObserver: null
 
 	# Add resize listening
 	mounted: ->
 		@onResize()
-		window.addEventListener 'resize', @onResize
 
-	# Cleanup listeners
-	beforeDestroy: -> window.removeEventListener 'resize', @onResize
+		# resize observer listens for the element itself
+		# changing dimensions
+		@resizeObserver = new ResizeObserver @onResize
+		@resizeObserver.observe @$el
+
+	beforeDestroy: ->
+		if @$el then @resizeObserver.unobserve(@$el)
+		else @resizeObserver.disconnect()
 
 	computed:
 
@@ -106,3 +112,8 @@ export default
 				(#{@autoUnit(peekLeft)} + #{@autoUnit(peekRight)}) / #{slidesPerPage} -
 				(#{@autoUnit(gutter)} * #{slidesPerPage - 1}) / #{slidesPerPage}
 			)"
+
+	# watch:
+	# 	'carouselWidth': ->
+	# 		console.log @carouselWidth
+	# 		@onResize()

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -7,7 +7,6 @@ export default
 		viewportWidth: null # Width of the viewport, for media query calculation
 		carouselWidth: null # Width of a page of the carousel
 		gutterWidth: 0 # Computed width of gutters, since they support css vars
-		resizeObserver: null
 
 	# Add resize listening
 	mounted: ->

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -112,8 +112,3 @@ export default
 				(#{@autoUnit(peekLeft)} + #{@autoUnit(peekRight)}) / #{slidesPerPage} -
 				(#{@autoUnit(gutter)} * #{slidesPerPage - 1}) / #{slidesPerPage}
 			)"
-
-	# watch:
-	# 	'carouselWidth': ->
-	# 		console.log @carouselWidth
-	# 		@onResize()

--- a/src/concerns/dimensions.coffee
+++ b/src/concerns/dimensions.coffee
@@ -12,8 +12,7 @@ export default
 	mounted: ->
 		@onResize()
 
-		# resize observer listens for the element itself
-		# changing dimensions
+		# Resize observer listens for the element itself to change dimensions
 		@resizeObserver = new ResizeObserver @onResize
 		@resizeObserver.observe @$el
 


### PR DESCRIPTION
@weotch check this out. I found that ditching window.resize and using resize observer helps with the following issue: 

- carousel mounts
- something other than window resizing causes it's dimensions to change
- it would not re-calc, so slides would dock appropriately

With this resizeObserver, it listens for dimension changes on the el, rather than window, so it works the same as before, but additionally will re-calc when it changes separately from the window size

https://caniuse.com/resizeobserver