### PR TITLE
Check if event is cancelable

### DIFF
--- a/src/concerns/dragging.coffee
+++ b/src/concerns/dragging.coffee
@@ -185,7 +185,9 @@ export default
 	methods:
 
 		# Cancel an Event
-		stopEvent: (e) -> e.preventDefault()
+		stopEvent: (e) ->
+			if e.cancelable
+			then e.preventDefault()
 
 		# Keep track of whether user is dragging
 		onPointerDown: (pointerEvent) ->


### PR DESCRIPTION
Mobile Chrome fires the following warning:

```
IgnoredEventCancel: Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```

Checking if event is cancelable suppresses this warning.
