### PR TITLE
aria-current

### DIFF
--- a/src/ssr-carousel-dots.vue
+++ b/src/ssr-carousel-dots.vue
@@ -6,7 +6,7 @@
 	button.ssr-carousel-dot-button(
 		v-for='i in pages' :key='i'
 		:aria-label='makeLabel(i)'
-		:aria-disabled='isDisabled(i)'
+		:aria-current='isDisabled(i)'
 		@click='$emit("goto", i - 1)')
 
 		//- Custom dot
@@ -71,14 +71,14 @@ export default
 	margin-h 4px
 
 	// Show disabled state (aka, the active state)
-	[aria-disabled] > &
+	[aria-current] > &
 		opacity 1
 		background rgba(black, 0.7)
 		cursor default
 
 	// Make a simple hover
 	transition opacity 0.2s
-	:not([aria-disabled]) > &
+	:not([aria-current]) > &
 		opacity 0.5
 		+hover()
 			opacity 0.85


### PR DESCRIPTION
Level access audit for COR flagged this as a high priority issue. Basically they are saying that `aria-disabled` shouldn't be how we set the active slide dot state. They suggest `aria-current`. 

I tested this simple change locally, and things seem to be fine, but I wanted to show you in case you think of some other reasons why we shouldn't do this. 

One ramification is that if other sites update the carousel package, they will need to update any custom styling that hooks into the disabled attribute...

![image](https://github.com/BKWLD/vue-ssr-carousel/assets/435606/9451c517-3751-4287-90c1-7554fe08cede)

From level access: 
![image](https://github.com/BKWLD/vue-ssr-carousel/assets/435606/d1dbdfa5-81c7-4d5c-8357-08c72f4072c7)
